### PR TITLE
Add headless build mode (no tray/gtk deps)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "eventsource-client"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2231,6 +2241,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2489,6 +2509,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,12 @@ description = "Discord Rich Presence for Plex"
 license = "MIT"
 repository = "https://github.com/abarnes6/presence-for-plex"
 
+[features]
+default = ["tray"]
+tray = ["tray-icon", "crossbeam-channel", "image", "gtk"]
+
 [dependencies]
-tokio = { version = "1.49", features = ["rt-multi-thread", "sync", "time", "macros"] }
+tokio = { version = "1.49", features = ["rt-multi-thread", "sync", "time", "macros", "signal"] }
 tokio-util = "0.7"
 reqwest = { version = "0.13", features = ["json", "stream", "query"] }
 eventsource-client = "0.16"
@@ -21,9 +25,9 @@ log = "0.4"
 simplelog = "0.12"
 dirs = "6"
 fs2 = "0.4"
-tray-icon = "0.21"
-crossbeam-channel = "0.5"
-image = { version = "0.25", default-features = false, features = ["ico"] }
+tray-icon = { version = "0.21", optional = true }
+crossbeam-channel = { version = "0.5", optional = true }
+image = { version = "0.25", default-features = false, features = ["ico"], optional = true }
 open = "5.3"
 percent-encoding = "2.3"
 
@@ -31,7 +35,7 @@ percent-encoding = "2.3"
 windows-sys = { version = "0.61", features = ["Win32_UI_WindowsAndMessaging"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-gtk = "0.18"
+gtk = { version = "0.18", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-core-foundation = { version = "0.3", features = ["CFRunLoop", "CFDate"] }


### PR DESCRIPTION
Note: This was made with AI assistant (kimi2.5), but from previous experience and knowledge I knew what I want to achieve here.

This PR adds the feature flag "tray" to default and allow users to build with "--no-default-features" which essentially will disable the "tray" (and its dependencies)

After this, I can also send a PR for Docker, and we going to need to update some documentation.

```
cargo build --release --no-default-features
```

This closes #13 

