### PR TITLE
Fix correctness bugs from project review, add unit tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: check (${{ matrix.os }}${{ matrix.features && ', ' || '' }}${{ matrix.features }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            features: ""
+          - os: ubuntu-latest
+            features: "--no-default-features"
+          - os: windows-latest
+            features: ""
+          - os: macos-latest
+            features: ""
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux' && matrix.features == ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libayatana-appindicator3-dev libxdo-dev
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Clippy
+        run: cargo clippy --all-targets ${{ matrix.features }} -- -D warnings
+      - name: Test
+        run: cargo test ${{ matrix.features }}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,23 @@ A lightweight Discord Rich Presence client for Plex. Shows what you're watching 
 
 ## Configuration
 
-Config file: `~/.config/presence-for-plex/config.yaml` (Windows: `%APPDATA%\presence-for-plex\config.yaml`)
+Config file locations:
+
+- Linux: `~/.config/presence-for-plex/config.yaml`
+- macOS: `~/Library/Application Support/presence-for-plex/config.yaml`
+- Windows: `%APPDATA%\presence-for-plex\config.yaml`
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `plex_token` | – | Plex auth token (set automatically by the auth flow) |
+| `tmdb_token` | – | Optional personal TMDB API read token for artwork |
+| `show_buttons` | `true` | Show IMDb/MyAnimeList link buttons |
+| `show_progress` | `true` | Show playback progress timestamps |
+| `show_artwork` | `true` | Show media artwork instead of the Plex logo |
+| `enable_movies` / `enable_tv_shows` / `enable_music` | `true` | Toggle presence per media type |
+| `tv_details`, `tv_state`, `tv_image_text`, `movie_*`, `music_*` | see defaults | Display templates (see variables below) |
 
 ### Template Variables
 
@@ -29,11 +45,28 @@ Config file: `~/.config/presence-for-plex/config.yaml` (Windows: `%APPDATA%\pres
 | `{artist}` | Music artist |
 | `{album}` | Album name |
 
+## Headless mode
+
+For servers or Docker-style setups you can build without the system tray (drops the GTK dependency on Linux):
+
+```sh
+cargo build --release --no-default-features
+```
+
+Since there is no tray menu in headless mode, authenticate once from the terminal:
+
+```sh
+presence-for-plex --auth
+```
+
+This prints a Plex link URL, waits for you to approve it, and saves the token to the config file. Then start the app normally. (`--auth` also works in the tray build.)
+
 ## Troubleshooting
 
-Check the log file:
-- Windows: `%APPDATA%\presence-for-plex\log.txt`
-- macOS/Linux: `~/.config/presence-for-plex/log.txt`
+Check the log file (`presence-for-plex.log`):
+- Linux: `~/.config/presence-for-plex/presence-for-plex.log`
+- macOS: `~/Library/Application Support/presence-for-plex/presence-for-plex.log`
+- Windows: `%APPDATA%\presence-for-plex\presence-for-plex.log`
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Config file locations:
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `plex_token` | – | Plex auth token (set automatically by the auth flow) |
-| `tmdb_token` | – | Optional personal TMDB API read token for artwork |
+| `plex_token` | unset | Plex auth token (set by the auth flow) |
+| `tmdb_token` | unset | Personal TMDB API read token for artwork |
 | `show_buttons` | `true` | Show IMDb/MyAnimeList link buttons |
 | `show_progress` | `true` | Show playback progress timestamps |
 | `show_artwork` | `true` | Show media artwork instead of the Plex logo |
@@ -47,19 +47,17 @@ Config file locations:
 
 ## Headless mode
 
-For servers or Docker-style setups you can build without the system tray (drops the GTK dependency on Linux):
+Build without the system tray (no GTK dependency on Linux):
 
 ```sh
 cargo build --release --no-default-features
 ```
 
-Since there is no tray menu in headless mode, authenticate once from the terminal:
+Authenticate once from the terminal, then start the app normally:
 
 ```sh
 presence-for-plex --auth
 ```
-
-This prints a Plex link URL, waits for you to approve it, and saves the token to the config file. Then start the app normally. (`--auth` also works in the tray build.)
 
 ## Troubleshooting
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,16 +56,31 @@ impl Default for Config {
 impl Config {
     pub fn load() -> Self {
         let path = Self::config_path();
-        if path.exists() {
-            if let Ok(contents) = std::fs::read_to_string(&path) {
-                if let Ok(config) = serde_yml::from_str(&contents) {
-                    return config;
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => match serde_yml::from_str(&contents) {
+                Ok(config) => config,
+                Err(e) => {
+                    // Never overwrite a config we couldn't parse - move it aside
+                    // so the user's settings (and token) can be recovered.
+                    log::error!("Failed to parse {}: {}", path.display(), e);
+                    let backup = path.with_extension("yaml.bak");
+                    match std::fs::rename(&path, &backup) {
+                        Ok(_) => log::warn!("Unparseable config backed up to {}", backup.display()),
+                        Err(e) => log::warn!("Could not back up config: {}", e),
+                    }
+                    Config::default()
                 }
+            },
+            Err(e) => {
+                let config = Config::default();
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    let _ = config.save();
+                } else {
+                    log::warn!("Could not read {}: {}", path.display(), e);
+                }
+                config
             }
         }
-        let config = Config::default();
-        let _ = config.save();
-        config
     }
 
     pub fn save(&self) -> std::io::Result<()> {
@@ -73,8 +88,15 @@ impl Config {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let contents = serde_yml::to_string(self).unwrap_or_default();
-        std::fs::write(&path, contents)
+        let contents = serde_yml::to_string(self).map_err(std::io::Error::other)?;
+        std::fs::write(&path, contents)?;
+        // The config holds the Plex token - keep it readable by the owner only.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+        }
+        Ok(())
     }
 
     fn config_path() -> PathBuf {
@@ -89,5 +111,36 @@ impl Config {
         dirs::config_dir()
             .unwrap_or_else(|| PathBuf::from("."))
             .join("presence-for-plex")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_roundtrip_through_yaml() {
+        let original = Config::default();
+        let yaml = serde_yml::to_string(&original).unwrap();
+        let parsed: Config = serde_yml::from_str(&yaml).unwrap();
+        assert_eq!(parsed.discord_client_id, original.discord_client_id);
+        assert_eq!(parsed.tv_state, original.tv_state);
+        assert_eq!(parsed.show_buttons, original.show_buttons);
+        assert_eq!(parsed.plex_token, original.plex_token);
+    }
+
+    #[test]
+    fn partial_config_fills_in_defaults() {
+        let parsed: Config = serde_yml::from_str("plex_token: abc123\nenable_music: false\n").unwrap();
+        assert_eq!(parsed.plex_token.as_deref(), Some("abc123"));
+        assert!(!parsed.enable_music);
+        assert!(parsed.enable_movies);
+        assert_eq!(parsed.discord_client_id, Config::default().discord_client_id);
+        assert_eq!(parsed.movie_details, Config::default().movie_details);
+    }
+
+    #[test]
+    fn invalid_yaml_fails_to_parse() {
+        assert!(serde_yml::from_str::<Config>("plex_token: [unclosed").is_err());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,13 +60,11 @@ impl Config {
             Ok(contents) => match serde_yml::from_str(&contents) {
                 Ok(config) => config,
                 Err(e) => {
-                    // Never overwrite a config we couldn't parse - move it aside
-                    // so the user's settings (and token) can be recovered.
                     log::error!("Failed to parse {}: {}", path.display(), e);
                     let backup = path.with_extension("yaml.bak");
                     match std::fs::rename(&path, &backup) {
-                        Ok(_) => log::warn!("Unparseable config backed up to {}", backup.display()),
-                        Err(e) => log::warn!("Could not back up config: {}", e),
+                        Ok(_) => log::warn!("Config backed up to {}", backup.display()),
+                        Err(e) => log::warn!("Config backup failed: {}", e),
                     }
                     Config::default()
                 }
@@ -90,7 +88,7 @@ impl Config {
         }
         let contents = serde_yml::to_string(self).map_err(std::io::Error::other)?;
         std::fs::write(&path, contents)?;
-        // The config holds the Plex token - keep it readable by the owner only.
+        // Contains the Plex token
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -38,9 +38,11 @@ impl DiscordClient {
 
         let mut b = activity::Activity::new()
             .activity_type(p.activity_type.into())
-            .status_display_type(display)
-            .details(&p.details)
-            .state(&p.state);
+            .status_display_type(display);
+
+        // Discord rejects presence strings shorter than 2 characters
+        if p.details.chars().count() >= 2 { b = b.details(&p.details); }
+        if p.state.chars().count() >= 2 { b = b.state(&p.state); }
 
         if p.show_timestamps {
             b = match p.playback_state {

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -40,7 +40,7 @@ impl DiscordClient {
             .activity_type(p.activity_type.into())
             .status_display_type(display);
 
-        // Discord rejects presence strings shorter than 2 characters
+        // Discord rejects strings under 2 chars
         if p.details.chars().count() >= 2 { b = b.details(&p.details); }
         if p.state.chars().count() >= 2 { b = b.state(&p.state); }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,7 @@ fn pump_messages() {
 #[cfg(target_os = "macos")]
 fn pump_macos() {
     use objc2_core_foundation::{CFRunLoop, kCFRunLoopDefaultMode};
-    CFRunLoop::run_in_mode(unsafe { kCFRunLoopDefaultMode.as_deref() }, 0.0, false);
+    CFRunLoop::run_in_mode(unsafe { kCFRunLoopDefaultMode }, 0.0, false);
 }
 
 async fn run_auth() -> Option<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,13 +29,16 @@ use tray::{TrayCommand, TrayStatus};
 
 const AUTH_TIMEOUT: Duration = Duration::from_secs(300);
 const AUTH_POLL_INTERVAL: Duration = Duration::from_secs(2);
+const DISCOVERY_RETRY_INITIAL: Duration = Duration::from_secs(5);
+const DISCOVERY_RETRY_MAX: Duration = Duration::from_secs(300);
 
-fn acquire_instance_lock() -> Option<File> {
-    let path = Config::app_dir().join("presence-for-plex.lock");
-    std::fs::create_dir_all(path.parent()?).ok();
-    let file = File::create(&path).ok()?;
-    file.try_lock_exclusive().ok()?;
-    Some(file)
+fn acquire_instance_lock() -> Result<File, String> {
+    let dir = Config::app_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Cannot create {}: {}", dir.display(), e))?;
+    let path = dir.join("presence-for-plex.lock");
+    let file = File::create(&path).map_err(|e| format!("Cannot create lock file {}: {}", path.display(), e))?;
+    file.try_lock_exclusive().map_err(|_| "Another instance is already running".to_string())?;
+    Ok(file)
 }
 
 fn init_logging() {
@@ -50,14 +53,30 @@ fn init_logging() {
     info!("Starting Presence for Plex - Log: {}", path.display());
 }
 
+fn spawn_monitoring(token: String, tmdb: Option<String>, cancel: &CancellationToken, media_tx: &mpsc::UnboundedSender<MediaUpdate>) -> CancellationToken {
+    let c = cancel.child_token();
+    let monitor_cancel = c.clone();
+    let tx = media_tx.clone();
+    tokio::spawn(async move { begin_monitoring(token, tmdb, tx, monitor_cancel).await });
+    c
+}
+
 #[tokio::main]
 async fn main() {
     let _lock = match acquire_instance_lock() {
-        Some(f) => f,
-        None => { eprintln!("Another instance running"); return; }
+        Ok(f) => f,
+        Err(e) => { eprintln!("{}", e); return; }
     };
 
     init_logging();
+
+    if std::env::args().any(|a| a == "--auth") {
+        match run_auth().await {
+            Some(_) => info!("Authentication successful - token saved. Start the app normally to begin monitoring."),
+            None => error!("Authentication failed or timed out"),
+        }
+        return;
+    }
 
     let config = Arc::new(Config::load());
     let cancel = CancellationToken::new();
@@ -74,14 +93,10 @@ async fn main() {
     discord.connect();
     let discord = Arc::new(Mutex::new(discord));
 
-    let mut sse_cancel = config.plex_token.as_ref().map(|token| {
-        let c = cancel.child_token();
-        let tx = media_tx.clone();
-        let tmdb = config.tmdb_token.clone();
-        let t = token.clone();
-        tokio::spawn(async move { begin_monitoring(t, tmdb, tx, c).await });
-        cancel.child_token()
-    });
+    #[cfg(feature = "tray")]
+    let mut sse_cancel = config.plex_token.clone().map(|token| spawn_monitoring(token, config.tmdb_token.clone(), &cancel, &media_tx));
+    #[cfg(not(feature = "tray"))]
+    let _sse_cancel = config.plex_token.clone().map(|token| spawn_monitoring(token, config.tmdb_token.clone(), &cancel, &media_tx));
 
     #[cfg(feature = "tray")]
     tokio::spawn({
@@ -99,56 +114,83 @@ async fn main() {
 
     #[cfg(feature = "tray")]
     {
-    let mut pump = tokio::time::interval(Duration::from_millis(16));
-    let (auth_result_tx, mut auth_result_rx) = mpsc::channel::<(String, Option<String>)>(1);
-    let mut auth_in_progress = false;
-    loop {
-        tokio::select! {
-            biased;
-            _ = pump.tick() => {
-                #[cfg(windows)]
-                pump_messages();
-                #[cfg(target_os = "macos")]
-                pump_macos();
-            }
-            Some((token, tmdb)) = auth_result_rx.recv() => {
-                auth_in_progress = false;
-                if let Some(h) = tray.as_ref() { h.set_auth_text("Reauthenticate"); h.set_status_text(TrayStatus::Idle.as_str()); }
-                if let Some(old) = sse_cancel.as_ref() { old.cancel(); }
-                let c = cancel.child_token();
-                sse_cancel = Some(c.clone());
-                let tx = media_tx.clone();
-                tokio::spawn(async move { begin_monitoring(token, tmdb, tx, c).await });
-            }
-            Some(status) = status_rx.recv() => { if let Some(h) = tray.as_ref() { h.set_status_text(status.as_str()); } }
-            msg = tray_rx.recv() => match msg {
-                Some(TrayCommand::Quit) => { cancel.cancel(); discord.lock().await.disconnect(); break; }
-                Some(TrayCommand::Authenticate) if !auth_in_progress => {
-                    auth_in_progress = true;
-                    let auth_tx = auth_result_tx.clone();
-                    let tmdb = config.tmdb_token.clone();
-                    tokio::spawn(async move { if let Some(r) = run_auth(tmdb).await { let _ = auth_tx.send(r).await; } });
+        if tray.is_none() {
+            warn!("System tray unavailable - running without tray (Ctrl+C to quit)");
+            tokio::signal::ctrl_c().await.ok();
+        } else {
+            // Windows/macOS need the UI event loop pumped from this thread; on Linux
+            // the tray runs its own GTK thread, so the tick is just a keepalive.
+            let pump_period = if cfg!(any(windows, target_os = "macos")) { Duration::from_millis(16) } else { Duration::from_secs(3600) };
+            let mut pump = tokio::time::interval(pump_period);
+            let (auth_result_tx, mut auth_result_rx) = mpsc::channel::<Option<String>>(1);
+            let mut auth_in_progress = false;
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = pump.tick() => {
+                        #[cfg(windows)]
+                        pump_messages();
+                        #[cfg(target_os = "macos")]
+                        pump_macos();
+                    }
+                    Some(result) = auth_result_rx.recv() => {
+                        auth_in_progress = false;
+                        match result {
+                            Some(token) => {
+                                if let Some(h) = tray.as_ref() { h.set_auth_text("Reauthenticate"); h.set_status_text(TrayStatus::Idle.as_str()); }
+                                if let Some(old) = sse_cancel.as_ref() { old.cancel(); }
+                                sse_cancel = Some(spawn_monitoring(token, config.tmdb_token.clone(), &cancel, &media_tx));
+                            }
+                            None => {
+                                warn!("Plex authentication failed or timed out");
+                                if sse_cancel.is_none() && let Some(h) = tray.as_ref() { h.set_status_text(TrayStatus::NotAuthenticated.as_str()); }
+                            }
+                        }
+                    }
+                    Some(status) = status_rx.recv() => { if let Some(h) = tray.as_ref() { h.set_status_text(status.as_str()); } }
+                    Some(msg) = tray_rx.recv() => match msg {
+                        TrayCommand::Quit => break,
+                        TrayCommand::Authenticate if !auth_in_progress => {
+                            auth_in_progress = true;
+                            let auth_tx = auth_result_tx.clone();
+                            tokio::spawn(async move { let _ = auth_tx.send(run_auth().await).await; });
+                        }
+                        _ => {}
+                    }
                 }
-                _ => {}
             }
         }
-    }
     }
 
     #[cfg(not(feature = "tray"))]
     tokio::signal::ctrl_c().await.ok();
 
+    cancel.cancel();
+    discord.lock().await.disconnect();
     info!("Shutting down");
 }
 
 async fn begin_monitoring(token: String, tmdb: Option<String>, tx: mpsc::UnboundedSender<MediaUpdate>, cancel: CancellationToken) {
     let enricher = Arc::new(MetadataEnricher::new(tmdb));
     let mut account = PlexAccount::new();
-    account.fetch_username(&token).await;
 
-    let servers = match account.get_servers(&token).await {
-        Some(s) if !s.is_empty() => s,
-        _ => { warn!("No Plex servers found"); return; }
+    // Server discovery can fail transiently (e.g. app starts before the network
+    // is up at login), so retry with backoff instead of giving up.
+    let mut delay = DISCOVERY_RETRY_INITIAL;
+    let servers = loop {
+        if account.username().is_none() && account.fetch_username(&token).await.is_none() {
+            warn!("Could not fetch Plex account info; retrying in {}s", delay.as_secs());
+        } else {
+            match account.get_servers(&token).await {
+                Some(s) if !s.is_empty() => break s,
+                _ => warn!("No Plex servers found; retrying in {}s", delay.as_secs()),
+            }
+        }
+        tokio::select! {
+            _ = cancel.cancelled() => return,
+            _ = tokio::time::sleep(delay) => {}
+        }
+        delay = (delay * 2).min(DISCOVERY_RETRY_MAX);
     };
 
     let username = account.username().map(String::from);
@@ -217,11 +259,12 @@ fn pump_macos() {
     CFRunLoop::run_in_mode(unsafe { kCFRunLoopDefaultMode.as_deref() }, 0.0, false);
 }
 
-async fn run_auth(tmdb: Option<String>) -> Option<(String, Option<String>)> {
+async fn run_auth() -> Option<String> {
     info!("Starting Plex auth");
     let account = PlexAccount::new();
     let (pin_id, code) = account.request_pin().await?;
     let url = format!("https://app.plex.tv/auth#?clientID={}&code={}&context%5Bdevice%5D%5Bproduct%5D=Presence%20for%20Plex", utf8_percent_encode(APP_NAME, NON_ALPHANUMERIC), utf8_percent_encode(&code, NON_ALPHANUMERIC));
+    println!("Open this URL to link your Plex account:\n{}", url);
     if let Err(e) = open::that(&url) { warn!("Browser failed: {}", e); }
 
     let token = tokio::time::timeout(AUTH_TIMEOUT, async {
@@ -232,5 +275,5 @@ async fn run_auth(tmdb: Option<String>) -> Option<(String, Option<String>)> {
     cfg.plex_token = Some(token.clone());
     if let Err(e) = cfg.save() { error!("Config save failed: {}", e); }
     info!("Auth complete");
-    Some((token, tmdb))
+    Some(token)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,8 +72,8 @@ async fn main() {
 
     if std::env::args().any(|a| a == "--auth") {
         match run_auth().await {
-            Some(_) => info!("Authentication successful - token saved. Start the app normally to begin monitoring."),
-            None => error!("Authentication failed or timed out"),
+            Some(_) => info!("Token saved"),
+            None => error!("Auth failed or timed out"),
         }
         return;
     }
@@ -115,11 +115,10 @@ async fn main() {
     #[cfg(feature = "tray")]
     {
         if tray.is_none() {
-            warn!("System tray unavailable - running without tray (Ctrl+C to quit)");
+            warn!("Tray unavailable, Ctrl+C to quit");
             tokio::signal::ctrl_c().await.ok();
         } else {
-            // Windows/macOS need the UI event loop pumped from this thread; on Linux
-            // the tray runs its own GTK thread, so the tick is just a keepalive.
+            // Only Windows/macOS need the UI loop pumped from this thread
             let pump_period = if cfg!(any(windows, target_os = "macos")) { Duration::from_millis(16) } else { Duration::from_secs(3600) };
             let mut pump = tokio::time::interval(pump_period);
             let (auth_result_tx, mut auth_result_rx) = mpsc::channel::<Option<String>>(1);
@@ -142,7 +141,7 @@ async fn main() {
                                 sse_cancel = Some(spawn_monitoring(token, config.tmdb_token.clone(), &cancel, &media_tx));
                             }
                             None => {
-                                warn!("Plex authentication failed or timed out");
+                                warn!("Auth failed or timed out");
                                 if sse_cancel.is_none() && let Some(h) = tray.as_ref() { h.set_status_text(TrayStatus::NotAuthenticated.as_str()); }
                             }
                         }
@@ -174,16 +173,15 @@ async fn begin_monitoring(token: String, tmdb: Option<String>, tx: mpsc::Unbound
     let enricher = Arc::new(MetadataEnricher::new(tmdb));
     let mut account = PlexAccount::new();
 
-    // Server discovery can fail transiently (e.g. app starts before the network
-    // is up at login), so retry with backoff instead of giving up.
+    // Retry discovery, the network may not be up yet at login
     let mut delay = DISCOVERY_RETRY_INITIAL;
     let servers = loop {
         if account.username().is_none() && account.fetch_username(&token).await.is_none() {
-            warn!("Could not fetch Plex account info; retrying in {}s", delay.as_secs());
+            warn!("Account fetch failed, retrying in {}s", delay.as_secs());
         } else {
             match account.get_servers(&token).await {
                 Some(s) if !s.is_empty() => break s,
-                _ => warn!("No Plex servers found; retrying in {}s", delay.as_secs()),
+                _ => warn!("No servers found, retrying in {}s", delay.as_secs()),
             }
         }
         tokio::select! {
@@ -264,7 +262,7 @@ async fn run_auth() -> Option<String> {
     let account = PlexAccount::new();
     let (pin_id, code) = account.request_pin().await?;
     let url = format!("https://app.plex.tv/auth#?clientID={}&code={}&context%5Bdevice%5D%5Bproduct%5D=Presence%20for%20Plex", utf8_percent_encode(APP_NAME, NON_ALPHANUMERIC), utf8_percent_encode(&code, NON_ALPHANUMERIC));
-    println!("Open this URL to link your Plex account:\n{}", url);
+    println!("Open to authenticate:\n{}", url);
     if let Err(e) = open::that(&url) { warn!("Browser failed: {}", e); }
 
     let token = tokio::time::timeout(AUTH_TIMEOUT, async {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -58,8 +58,7 @@ impl MetadataEnricher {
             }
         }
 
-        // For anime, fetch MAL ID for the link. Only the "anime" genre counts -
-        // "animation" would match Western cartoons and produce bogus MAL links.
+        // For anime, fetch MAL ID for the link ("animation" alone is not anime)
         let is_anime = info.genres.iter().any(|g| g.eq_ignore_ascii_case("anime"));
         if is_anime && info.media_type != MediaType::Track {
             self.fetch_mal_id(info).await;
@@ -161,7 +160,7 @@ impl MetadataEnricher {
             let mut c = cache.write().unwrap();
             c.retain(|_, e| e.timestamp.elapsed() < CACHE_TTL);
             if c.len() >= CACHE_CLEANUP_THRESHOLD {
-                // Everything is still fresh - evict the older half to cap growth
+                // Still full, evict the older half
                 let mut stamps: Vec<Instant> = c.values().map(|e| e.timestamp).collect();
                 stamps.sort();
                 let cutoff = stamps[stamps.len() / 2];

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -58,8 +58,9 @@ impl MetadataEnricher {
             }
         }
 
-        // For anime, fetch MAL ID for the link
-        let is_anime = info.genres.iter().any(|g| matches!(g.to_lowercase().as_str(), "anime" | "animation"));
+        // For anime, fetch MAL ID for the link. Only the "anime" genre counts -
+        // "animation" would match Western cartoons and produce bogus MAL links.
+        let is_anime = info.genres.iter().any(|g| g.eq_ignore_ascii_case("anime"));
         if is_anime && info.media_type != MediaType::Track {
             self.fetch_mal_id(info).await;
         }
@@ -85,8 +86,10 @@ impl MetadataEnricher {
             MediaType::Episode => {
                 // Try season-specific artwork first, fall back to show artwork
                 let season = info.season.unwrap_or(1);
-                self.fetch_tmdb_images(&format!("/tv/{}/season/{}/images", tmdb_id, season)).await
-                    .or(self.fetch_tmdb_images(&format!("/tv/{}/images", tmdb_id)).await)
+                match self.fetch_tmdb_images(&format!("/tv/{}/season/{}/images", tmdb_id, season)).await {
+                    Some(url) => Some(url),
+                    None => self.fetch_tmdb_images(&format!("/tv/{}/images", tmdb_id)).await,
+                }
             }
             _ => return false,
         };
@@ -113,7 +116,7 @@ impl MetadataEnricher {
             return;
         }
 
-        let url = format!("{}?q={}&limit=1", JIKAN_API, utf8_percent_encode(&cache_key, NON_ALPHANUMERIC));
+        let url = format!("{}?q={}&limit=1", JIKAN_API, utf8_percent_encode(title, NON_ALPHANUMERIC));
 
         let mal_id = async {
             let resp = self.client.get(&url).send().await.ok()?;
@@ -152,9 +155,17 @@ impl MetadataEnricher {
 
     fn cleanup_cache(&self) {
         for cache in [&self.art_cache, &self.mal_cache] {
+            if cache.read().unwrap().len() < CACHE_CLEANUP_THRESHOLD {
+                continue;
+            }
             let mut c = cache.write().unwrap();
+            c.retain(|_, e| e.timestamp.elapsed() < CACHE_TTL);
             if c.len() >= CACHE_CLEANUP_THRESHOLD {
-                c.retain(|_, e| e.timestamp.elapsed() < CACHE_TTL);
+                // Everything is still fresh - evict the older half to cap growth
+                let mut stamps: Vec<Instant> = c.values().map(|e| e.timestamp).collect();
+                stamps.sort();
+                let cutoff = stamps[stamps.len() / 2];
+                c.retain(|_, e| e.timestamp > cutoff);
             }
         }
     }
@@ -190,3 +201,64 @@ struct JikanAnime { mal_id: u64 }
 struct MbSearch { releases: Vec<MbRelease> }
 #[derive(Deserialize)]
 struct MbRelease { id: String }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enricher() -> MetadataEnricher {
+        MetadataEnricher::new(None)
+    }
+
+    #[test]
+    fn cache_key_for_track_uses_artist_and_album() {
+        let mut info = MediaInfo::test_stub(MediaType::Track);
+        info.artist = Some("Artist".into());
+        info.album = Some("Album".into());
+        assert_eq!(enricher().cache_key(&info), "mb:Artist:Album");
+    }
+
+    #[test]
+    fn cache_key_for_episode_prefers_tmdb_id_and_season() {
+        let mut info = MediaInfo::test_stub(MediaType::Episode);
+        info.tmdb_id = Some("42".into());
+        info.season = Some(3);
+        assert_eq!(enricher().cache_key(&info), "tmdb:42:s3");
+    }
+
+    #[test]
+    fn cache_key_for_episode_falls_back_to_show_name() {
+        let mut info = MediaInfo::test_stub(MediaType::Episode);
+        info.show_name = Some("Some Show".into());
+        assert_eq!(enricher().cache_key(&info), "title:Some Show:s1");
+    }
+
+    #[test]
+    fn cache_key_for_movie_falls_back_to_title_and_year() {
+        let mut info = MediaInfo::test_stub(MediaType::Movie);
+        info.title = "Some Movie".into();
+        info.year = Some(1999);
+        assert_eq!(enricher().cache_key(&info), "title:Some Movie:1999");
+    }
+
+    #[test]
+    fn art_cache_stores_and_expires_nothing_when_fresh() {
+        let e = enricher();
+        e.set_art_cached("k", Some("url".into()));
+        assert_eq!(e.get_art_cached("k"), Some(Some("url".into())));
+        // Negative results are cached too
+        e.set_art_cached("miss", None);
+        assert_eq!(e.get_art_cached("miss"), Some(None));
+        assert_eq!(e.get_art_cached("absent"), None);
+    }
+
+    #[test]
+    fn cleanup_caps_cache_size_even_when_entries_are_fresh() {
+        let e = enricher();
+        for i in 0..CACHE_CLEANUP_THRESHOLD {
+            e.set_art_cached(&format!("k{}", i), None);
+        }
+        e.cleanup_cache();
+        assert!(e.art_cache.read().unwrap().len() < CACHE_CLEANUP_THRESHOLD);
+    }
+}

--- a/src/plex_server.rs
+++ b/src/plex_server.rs
@@ -46,6 +46,33 @@ pub struct MediaInfo {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum MediaType { Movie, Episode, Track }
 
+#[cfg(test)]
+impl MediaInfo {
+    pub fn test_stub(media_type: MediaType) -> Self {
+        Self {
+            title: "Title".into(),
+            media_type,
+            show_name: None,
+            season: None,
+            episode: None,
+            artist: None,
+            album: None,
+            year: None,
+            genres: Vec::new(),
+            duration_ms: 0,
+            view_offset_ms: 0,
+            state: PlaybackState::Playing,
+            imdb_id: None,
+            tmdb_id: None,
+            mal_id: None,
+            art_url: None,
+            rating_key: None,
+            grandparent_key: None,
+            key: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PlaybackState { Playing, Paused, Buffering }
 
@@ -366,4 +393,134 @@ struct ItemMetadata {
     #[serde(rename = "grandparentKey")]
     grandparent_key: Option<String>,
     key: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn playing_info(rating_key: &str, offset: u64) -> MediaInfo {
+        let mut info = MediaInfo::test_stub(MediaType::Movie);
+        info.rating_key = Some(rating_key.to_string());
+        info.view_offset_ms = offset;
+        info
+    }
+
+    #[test]
+    fn tracker_detects_duplicate_progress_updates() {
+        let mut t = PlaybackTracker::default();
+        t.set(playing_info("1", 1000), "http://server");
+        // Same item/state with offset within the seek threshold is a duplicate
+        assert!(t.is_duplicate("1", PlaybackState::Playing, 1000));
+        assert!(t.is_duplicate("1", PlaybackState::Playing, 20_000));
+    }
+
+    #[test]
+    fn tracker_treats_seek_as_new_update() {
+        let mut t = PlaybackTracker::default();
+        t.set(playing_info("1", 1000), "http://server");
+        assert!(!t.is_duplicate("1", PlaybackState::Playing, 1000 + SEEK_THRESHOLD_MS + 1));
+    }
+
+    #[test]
+    fn tracker_treats_state_change_or_new_item_as_new_update() {
+        let mut t = PlaybackTracker::default();
+        t.set(playing_info("1", 1000), "http://server");
+        assert!(!t.is_duplicate("1", PlaybackState::Paused, 1000));
+        assert!(!t.is_duplicate("2", PlaybackState::Playing, 1000));
+    }
+
+    #[test]
+    fn tracker_is_empty_by_default() {
+        let t = PlaybackTracker::default();
+        assert!(!t.is_duplicate("1", PlaybackState::Playing, 0));
+    }
+
+    #[test]
+    fn tracker_update_applies_state_and_offset() {
+        let mut t = PlaybackTracker::default();
+        t.set(playing_info("1", 1000), "http://server");
+        t.update(PlaybackState::Paused, 5000);
+        let info = t.info.as_ref().unwrap();
+        assert_eq!(info.state, PlaybackState::Paused);
+        assert_eq!(info.view_offset_ms, 5000);
+    }
+
+    #[test]
+    fn tracker_clears_only_for_matching_server() {
+        let mut t = PlaybackTracker::default();
+        t.set(playing_info("1", 0), "http://a");
+        assert!(!t.clear_if_server("http://b"));
+        assert!(t.info.is_some());
+        assert!(t.clear_if_server("http://a"));
+        assert!(t.info.is_none());
+    }
+
+    #[test]
+    fn parse_metadata_maps_episode_fields() {
+        let meta: ItemMetadata = serde_json::from_str(r#"{
+            "title": "The One Where It Works",
+            "type": "episode",
+            "duration": 1320000,
+            "year": 1994,
+            "grandparentTitle": "Friends",
+            "parentIndex": 1,
+            "index": 2,
+            "parentTitle": "Season 1",
+            "Guid": [{"id": "imdb://tt0583459"}, {"id": "tmdb://123"}],
+            "Genre": [{"tag": "Comedy"}],
+            "grandparentKey": "/library/metadata/100"
+        }"#).unwrap();
+
+        let info = PlexServer::parse_metadata(meta, "42", PlaybackState::Playing, 5000).unwrap();
+        assert_eq!(info.media_type, MediaType::Episode);
+        assert_eq!(info.title, "The One Where It Works");
+        assert_eq!(info.show_name.as_deref(), Some("Friends"));
+        assert_eq!(info.season, Some(1));
+        assert_eq!(info.episode, Some(2));
+        assert_eq!(info.imdb_id.as_deref(), Some("tt0583459"));
+        assert_eq!(info.tmdb_id.as_deref(), Some("123"));
+        assert_eq!(info.genres, vec!["Comedy".to_string()]);
+        assert_eq!(info.duration_ms, 1320000);
+        assert_eq!(info.view_offset_ms, 5000);
+        assert_eq!(info.rating_key.as_deref(), Some("42"));
+        assert_eq!(info.grandparent_key.as_deref(), Some("/library/metadata/100"));
+    }
+
+    #[test]
+    fn parse_metadata_maps_track_fields() {
+        let meta: ItemMetadata = serde_json::from_str(r#"{
+            "title": "Song",
+            "type": "track",
+            "grandparentTitle": "Artist",
+            "parentTitle": "Album"
+        }"#).unwrap();
+
+        let info = PlexServer::parse_metadata(meta, "7", PlaybackState::Paused, 0).unwrap();
+        assert_eq!(info.media_type, MediaType::Track);
+        assert_eq!(info.artist.as_deref(), Some("Artist"));
+        assert_eq!(info.album.as_deref(), Some("Album"));
+        assert_eq!(info.duration_ms, 0);
+    }
+
+    #[test]
+    fn parse_metadata_rejects_unknown_types() {
+        let meta: ItemMetadata = serde_json::from_str(r#"{"title": "Photo", "type": "photo"}"#).unwrap();
+        assert!(PlexServer::parse_metadata(meta, "1", PlaybackState::Playing, 0).is_none());
+    }
+
+    #[test]
+    fn sse_notification_parses_plex_payload() {
+        let notif: SseNotification = serde_json::from_str(r#"{
+            "PlaySessionStateNotification": {
+                "state": "playing",
+                "ratingKey": "123",
+                "viewOffset": 60000
+            }
+        }"#).unwrap();
+        let playing = notif.play_session_state.unwrap();
+        assert_eq!(playing.state, "playing");
+        assert_eq!(playing.rating_key, "123");
+        assert_eq!(playing.view_offset, Some(60000));
+    }
 }

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -14,7 +14,7 @@ pub fn build_presence(info: &MediaInfo, config: &Config) -> Presence {
     let mut buttons = Vec::new();
     if config.show_buttons {
         if let Some(ref id) = info.mal_id { buttons.push(Button { label: "View on MyAnimeList".into(), url: format!("https://myanimelist.net/anime/{}", id) }); }
-        if let Some(ref id) = info.imdb_id { if buttons.len() < 2 { buttons.push(Button { label: "View on IMDb".into(), url: format!("https://www.imdb.com/title/{}", id) }); } }
+        if let Some(ref id) = info.imdb_id && buttons.len() < 2 { buttons.push(Button { label: "View on IMDb".into(), url: format!("https://www.imdb.com/title/{}", id) }); }
     }
 
     Presence {
@@ -38,7 +38,18 @@ fn format_template(template: &str, info: &MediaInfo) -> String {
     while let Some(c) = chars.next() {
         if c == '{' {
             if chars.peek() == Some(&'{') { chars.next(); result.push('{'); continue; }
-            let placeholder: String = chars.by_ref().take_while(|&ch| ch != '}').collect();
+            let mut placeholder = String::new();
+            let mut closed = false;
+            for ch in chars.by_ref() {
+                if ch == '}' { closed = true; break; }
+                placeholder.push(ch);
+            }
+            if !closed {
+                // Unterminated placeholder - emit it verbatim
+                result.push('{');
+                result.push_str(&placeholder);
+                break;
+            }
             match placeholder.as_str() {
                 "show" => result.push_str(info.show_name.as_deref().unwrap_or("")),
                 "title" => result.push_str(&info.title),
@@ -55,4 +66,98 @@ fn format_template(template: &str, info: &MediaInfo) -> String {
         else { result.push(c); }
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn episode_info() -> MediaInfo {
+        let mut info = MediaInfo::test_stub(MediaType::Episode);
+        info.title = "Pilot".into();
+        info.show_name = Some("The Show".into());
+        info.season = Some(1);
+        info.episode = Some(2);
+        info.year = Some(2020);
+        info.genres = vec!["Drama".into(), "Comedy".into()];
+        info
+    }
+
+    #[test]
+    fn replaces_known_placeholders() {
+        let info = episode_info();
+        assert_eq!(format_template("{show}: {title}", &info), "The Show: Pilot");
+        assert_eq!(format_template("S{season} · E{episode}", &info), "S1 · E2");
+        assert_eq!(format_template("{year} [{genres}]", &info), "2020 [Drama, Comedy]");
+    }
+
+    #[test]
+    fn se_placeholder_is_zero_padded() {
+        let info = episode_info();
+        assert_eq!(format_template("{se}", &info), "S01E02");
+    }
+
+    #[test]
+    fn missing_values_render_empty() {
+        let info = MediaInfo::test_stub(MediaType::Movie);
+        assert_eq!(format_template("{show}{season}{episode}{year}{se}", &info), "");
+        assert_eq!(format_template("{artist} - {album}", &info), " - ");
+    }
+
+    #[test]
+    fn unknown_placeholders_are_preserved() {
+        let info = episode_info();
+        assert_eq!(format_template("{nope} {title}", &info), "{nope} Pilot");
+    }
+
+    #[test]
+    fn escaped_braces_are_literal() {
+        let info = episode_info();
+        assert_eq!(format_template("{{title}} = {title}", &info), "{title} = Pilot");
+    }
+
+    #[test]
+    fn unterminated_placeholder_is_preserved() {
+        let info = episode_info();
+        assert_eq!(format_template("oops {title", &info), "oops {title");
+    }
+
+    #[test]
+    fn build_presence_orders_and_caps_buttons() {
+        let mut info = episode_info();
+        info.mal_id = Some("100".into());
+        info.imdb_id = Some("tt1".into());
+        let p = build_presence(&info, &Config::default());
+        assert_eq!(p.buttons.len(), 2);
+        assert!(p.buttons[0].url.contains("myanimelist.net/anime/100"));
+        assert!(p.buttons[1].url.contains("imdb.com/title/tt1"));
+    }
+
+    #[test]
+    fn build_presence_respects_show_buttons_toggle() {
+        let mut info = episode_info();
+        info.imdb_id = Some("tt1".into());
+        let config = Config { show_buttons: false, ..Config::default() };
+        assert!(build_presence(&info, &config).buttons.is_empty());
+    }
+
+    #[test]
+    fn tracks_use_listening_activity() {
+        let info = MediaInfo::test_stub(MediaType::Track);
+        let p = build_presence(&info, &Config::default());
+        assert!(matches!(p.activity_type, ActivityType::Listening));
+        let p = build_presence(&episode_info(), &Config::default());
+        assert!(matches!(p.activity_type, ActivityType::Watching));
+    }
+
+    #[test]
+    fn artwork_toggle_falls_back_to_default_image() {
+        let mut info = episode_info();
+        info.art_url = Some("https://img.example/x.jpg".into());
+        let p = build_presence(&info, &Config::default());
+        assert_eq!(p.large_image.as_deref(), Some("https://img.example/x.jpg"));
+        let config = Config { show_artwork: false, ..Config::default() };
+        let p = build_presence(&info, &config);
+        assert_eq!(p.large_image.as_deref(), Some(DEFAULT_IMAGE));
+    }
 }

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -45,7 +45,7 @@ fn format_template(template: &str, info: &MediaInfo) -> String {
                 placeholder.push(ch);
             }
             if !closed {
-                // Unterminated placeholder - emit it verbatim
+                // Unterminated placeholder, emit verbatim
                 result.push('{');
                 result.push_str(&placeholder);
                 break;

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -103,7 +103,7 @@ pub fn setup(tx: UnboundedSender<TrayCommand>, authenticated: bool) -> Option<Tr
     let (update_tx, update_rx) = std::sync::mpsc::channel::<MenuTextUpdate>();
     std::thread::spawn(move || {
         if gtk::init().is_err() {
-            log::error!("Failed to initialize GTK - tray disabled");
+            log::error!("GTK init failed");
             ready_tx.send(false).ok();
             return;
         }

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -102,7 +102,11 @@ pub fn setup(tx: UnboundedSender<TrayCommand>, authenticated: bool) -> Option<Tr
     let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(1);
     let (update_tx, update_rx) = std::sync::mpsc::channel::<MenuTextUpdate>();
     std::thread::spawn(move || {
-        gtk::init().expect("Failed to initialize GTK");
+        if gtk::init().is_err() {
+            log::error!("Failed to initialize GTK - tray disabled");
+            ready_tx.send(false).ok();
+            return;
+        }
         let result = build_tray(tx, authenticated);
         if result.is_none() {
             ready_tx.send(false).ok();


### PR DESCRIPTION
Fixes a set of correctness bugs found during a full project review, adds unit tests for the pure logic, and introduces a CI workflow.

## Bug fixes

- **Config is no longer wiped by a parse error** — `Config::load()` used to fall through to defaults and save on *any* failure, so a YAML typo silently overwrote the user's token and settings. Unparseable configs are now backed up to `config.yaml.bak` and the error is logged.
- **Re-authentication stops the old monitor** — the initial monitoring spawn stored a *sibling* cancellation token instead of the one passed to the task, so "Reauthenticate" left the old monitoring tasks running alongside the new ones. Both spawn paths now share a `spawn_monitoring` helper that returns the correct token.
- **Auth button no longer dies after a failed attempt** — the auth task now always sends a result, so a timeout or failure resets `auth_in_progress` instead of leaving the tray's Authenticate item permanently ignored until restart.
- **No more 100% CPU busy-loop when tray setup fails** — the app falls back to a Ctrl+C wait when the tray is unavailable, the select arms use `Some(...)` patterns so a closed channel disables the arm instead of hot-spinning, and GTK init failure no longer panics the tray thread.
- **Server discovery retries with backoff** (5s → 5min cap) — starting the app before the network is up (e.g. at login) previously gave up permanently after one attempt. The username fetch is retried too, which also fixes the owner session check being silently disabled by one failed `/user` request.
- **Jikan/MAL search queried the cache key** (`"Title_2023"` / `"Title_0"`) instead of the title; it now sends the actual title. Only the `anime` genre triggers MAL lookups anymore — `animation` matched Western cartoons and produced bogus MyAnimeList buttons.
- **Episode artwork no longer double-fetches TMDB** — eager `.or(...)` evaluation fired the show-level images request even when season artwork was already found.
- **Metadata cache growth is capped** — previously, 100+ fresh entries grew unboundedly since cleanup only pruned expired ones; it now evicts the older half when full of fresh entries, and skips lock contention with a read-lock length check.
- **Discord presence strings shorter than 2 characters are omitted** — Discord rejects them, and the resulting error disconnected the client (e.g. a movie with no genres and the default `{genres}` state template).
- **Template parser preserves unterminated placeholders** verbatim instead of swallowing the rest of the string and appending a stray `}`.
- **Instance lock reports the actual error** instead of always claiming another instance is running.
- **Linux no longer ticks the no-op UI pump 60×/second** — the 16ms message pump is only needed on Windows/macOS.

## Improvements

- **`--auth` flag** runs the Plex PIN flow from the terminal and prints the link URL, so headless (`--no-default-features`) builds can finally authenticate — previously there was no auth path at all without the tray.
- Config file is written with `0600` permissions on Unix, since it holds the Plex token.
- The app now cancels monitoring and disconnects Discord (clearing the presence) on shutdown in all modes, not just via the tray Quit item.
- README corrections: actual log file name (`presence-for-plex.log`, not `log.txt`), correct macOS paths (`~/Library/Application Support/...`), plus new docs for config options and headless mode.

## Tests and CI

- 29 unit tests covering the template engine (placeholders, `{se}` padding, escaped/unterminated braces), presence building (button order/cap, activity types, artwork toggle), `PlaybackTracker` dedup/seek/clear logic, Plex metadata JSON parsing, metadata cache keys, and config serde defaults.
- New CI workflow runs `cargo clippy --all-targets -- -D warnings` and `cargo test` on Linux (default and `--no-default-features`), Windows, and macOS.

## Verification

- Both feature builds pass clippy with `-D warnings`; all 29 tests pass.
- Smoke-ran the headless binary: clean startup, graceful handling of Discord being absent, config created with `0600`.
- Verified the corrupted-config path end-to-end: parse error logged, original file preserved as `config.yaml.bak`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bq7rGEpJnff3TYSemYFhPW