### PR TITLE
Restructure for readability and adopt rustfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,10 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libayatana-appindicator3-dev libxdo-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
+      - name: Format
+        run: cargo fmt --check
       - name: Clippy
         run: cargo clippy --all-targets ${{ matrix.features }} -- -D warnings
       - name: Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,16 +436,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,7 +1639,6 @@ dependencies = [
  "dirs",
  "discord-rich-presence",
  "eventsource-client",
- "fs2",
  "futures-util",
  "gtk",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ discord-rich-presence = "1.1"
 log = "0.4"
 simplelog = "0.12"
 dirs = "6"
-fs2 = "0.4"
 tray-icon = { version = "0.21", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
 image = { version = "0.25", default-features = false, features = ["ico"], optional = true }

--- a/src/config.rs
+++ b/src/config.rs
@@ -129,11 +129,15 @@ mod tests {
 
     #[test]
     fn partial_config_fills_in_defaults() {
-        let parsed: Config = serde_yml::from_str("plex_token: abc123\nenable_music: false\n").unwrap();
+        let parsed: Config =
+            serde_yml::from_str("plex_token: abc123\nenable_music: false\n").unwrap();
         assert_eq!(parsed.plex_token.as_deref(), Some("abc123"));
         assert!(!parsed.enable_music);
         assert!(parsed.enable_movies);
-        assert_eq!(parsed.discord_client_id, Config::default().discord_client_id);
+        assert_eq!(
+            parsed.discord_client_id,
+            Config::default().discord_client_id
+        );
         assert_eq!(parsed.movie_details, Config::default().movie_details);
     }
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,4 +1,4 @@
-use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
+use discord_rich_presence::{DiscordIpc, DiscordIpcClient, activity};
 use log::{error, info};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -13,36 +13,65 @@ pub struct DiscordClient {
 
 impl DiscordClient {
     pub fn new(client_id: &str) -> Self {
-        Self { client: DiscordIpcClient::new(client_id), connected: false }
+        Self {
+            client: DiscordIpcClient::new(client_id),
+            connected: false,
+        }
     }
 
     pub fn connect(&mut self) -> bool {
-        if self.connected { self.disconnect(); }
+        if self.connected {
+            self.disconnect();
+        }
         match self.client.connect() {
-            Ok(_) => { info!("Connected to Discord"); self.connected = true; true }
-            Err(e) => { error!("Discord connect failed: {}", e); false }
+            Ok(_) => {
+                info!("Connected to Discord");
+                self.connected = true;
+                true
+            }
+            Err(e) => {
+                error!("Discord connect failed: {}", e);
+                false
+            }
         }
     }
 
     pub fn disconnect(&mut self) {
-        if self.connected { let _ = self.client.close(); self.connected = false; }
+        if self.connected {
+            let _ = self.client.close();
+            self.connected = false;
+        }
     }
 
-    pub fn is_connected(&self) -> bool { self.connected }
+    pub fn is_connected(&self) -> bool {
+        self.connected
+    }
 
     pub fn update(&mut self, p: &Presence) {
-        if !self.connected { return; }
+        if !self.connected {
+            return;
+        }
 
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs() as i64).unwrap_or(0);
-        let display = match p.activity_type { ActivityType::Listening => activity::StatusDisplayType::State, _ => activity::StatusDisplayType::Details };
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let display = match p.activity_type {
+            ActivityType::Listening => activity::StatusDisplayType::State,
+            _ => activity::StatusDisplayType::Details,
+        };
 
         let mut b = activity::Activity::new()
             .activity_type(p.activity_type.into())
             .status_display_type(display);
 
         // Discord rejects strings under 2 chars
-        if p.details.chars().count() >= 2 { b = b.details(&p.details); }
-        if p.state.chars().count() >= 2 { b = b.state(&p.state); }
+        if p.details.chars().count() >= 2 {
+            b = b.details(&p.details);
+        }
+        if p.state.chars().count() >= 2 {
+            b = b.state(&p.state);
+        }
 
         if p.show_timestamps {
             b = match p.playback_state {
@@ -53,24 +82,45 @@ impl DiscordClient {
                 }
                 PlaybackState::Paused | PlaybackState::Buffering => {
                     let dur = (p.duration_ms / 1000) as i64;
-                    b.timestamps(activity::Timestamps::new().start(now + PAUSED_OFFSET).end(now + PAUSED_OFFSET + dur))
+                    b.timestamps(
+                        activity::Timestamps::new()
+                            .start(now + PAUSED_OFFSET)
+                            .end(now + PAUSED_OFFSET + dur),
+                    )
                 }
             };
         }
 
         let mut assets = activity::Assets::new();
-        if let Some(ref url) = p.large_image { assets = assets.large_image(url).large_text(&p.large_image_text); }
-        if p.playback_state == PlaybackState::Paused { assets = assets.small_image("paused").small_text("Paused"); }
+        if let Some(ref url) = p.large_image {
+            assets = assets.large_image(url).large_text(&p.large_image_text);
+        }
+        if p.playback_state == PlaybackState::Paused {
+            assets = assets.small_image("paused").small_text("Paused");
+        }
         b = b.assets(assets);
 
         if !p.buttons.is_empty() {
-            b = b.buttons(p.buttons.iter().take(2).map(|btn| activity::Button::new(&btn.label, &btn.url)).collect());
+            b = b.buttons(
+                p.buttons
+                    .iter()
+                    .take(2)
+                    .map(|btn| activity::Button::new(&btn.label, &btn.url))
+                    .collect(),
+            );
         }
 
-        if let Err(e) = self.client.set_activity(b) { error!("Presence update failed: {}", e); self.disconnect(); }
+        if let Err(e) = self.client.set_activity(b) {
+            error!("Presence update failed: {}", e);
+            self.disconnect();
+        }
     }
 
-    pub fn clear(&mut self) { if self.connected { let _ = self.client.clear_activity(); } }
+    pub fn clear(&mut self) {
+        if self.connected {
+            let _ = self.client.clear_activity();
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -88,13 +138,22 @@ pub struct Presence {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum ActivityType { Watching, Listening }
+pub enum ActivityType {
+    Watching,
+    Listening,
+}
 
 impl From<ActivityType> for activity::ActivityType {
     fn from(t: ActivityType) -> Self {
-        match t { ActivityType::Watching => activity::ActivityType::Watching, ActivityType::Listening => activity::ActivityType::Listening }
+        match t {
+            ActivityType::Watching => activity::ActivityType::Watching,
+            ActivityType::Listening => activity::ActivityType::Listening,
+        }
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct Button { pub label: String, pub url: String }
+pub struct Button {
+    pub label: String,
+    pub url: String,
+}

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -2,8 +2,9 @@ use discord_rich_presence::{DiscordIpc, DiscordIpcClient, activity};
 use log::{error, info};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::plex_server::PlaybackState;
+use crate::media::PlaybackState;
 
+// Timestamps this far out render as a frozen clock in Discord
 const PAUSED_OFFSET: i64 = 9999 * 3600;
 
 pub struct DiscordClient {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 mod config;
 mod discord;
+mod media;
 mod metadata;
 mod plex_account;
 mod plex_server;
@@ -11,12 +12,12 @@ mod tray;
 
 use config::Config;
 use discord::DiscordClient;
-use fs2::FileExt;
 use log::{error, info, warn};
+use media::{MediaType, MediaUpdate};
 use metadata::MetadataEnricher;
 use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use plex_account::{APP_NAME, PlexAccount};
-use plex_server::{MediaType, MediaUpdate, PlexServer};
+use plex_server::PlexServer;
 use presence::build_presence;
 use simplelog::{CombinedLogger, Config as LogConfig, LevelFilter, SimpleLogger, WriteLogger};
 use std::fs::File;
@@ -25,52 +26,12 @@ use std::time::Duration;
 use tokio::sync::{Mutex, mpsc};
 use tokio_util::sync::CancellationToken;
 #[cfg(feature = "tray")]
-use tray::{TrayCommand, TrayStatus};
+use tray::{TrayCommand, TrayHandle, TrayStatus};
 
 const AUTH_TIMEOUT: Duration = Duration::from_secs(300);
 const AUTH_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const DISCOVERY_RETRY_INITIAL: Duration = Duration::from_secs(5);
 const DISCOVERY_RETRY_MAX: Duration = Duration::from_secs(300);
-
-fn acquire_instance_lock() -> Result<File, String> {
-    let dir = Config::app_dir();
-    std::fs::create_dir_all(&dir).map_err(|e| format!("Cannot create {}: {}", dir.display(), e))?;
-    let path = dir.join("presence-for-plex.lock");
-    let file = File::create(&path)
-        .map_err(|e| format!("Cannot create lock file {}: {}", path.display(), e))?;
-    file.try_lock_exclusive()
-        .map_err(|_| "Another instance is already running".to_string())?;
-    Ok(file)
-}
-
-fn init_logging() {
-    let path = Config::log_path();
-    std::fs::create_dir_all(path.parent().unwrap()).ok();
-    let level = std::env::var("RUST_LOG")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(LevelFilter::Info);
-    let mut loggers: Vec<Box<dyn simplelog::SharedLogger>> =
-        vec![SimpleLogger::new(level, LogConfig::default())];
-    if let Ok(file) = File::create(&path) {
-        loggers.push(WriteLogger::new(level, LogConfig::default(), file));
-    }
-    let _ = CombinedLogger::init(loggers);
-    info!("Starting Presence for Plex - Log: {}", path.display());
-}
-
-fn spawn_monitoring(
-    token: String,
-    tmdb: Option<String>,
-    cancel: &CancellationToken,
-    media_tx: &mpsc::UnboundedSender<MediaUpdate>,
-) -> CancellationToken {
-    let c = cancel.child_token();
-    let monitor_cancel = c.clone();
-    let tx = media_tx.clone();
-    tokio::spawn(async move { begin_monitoring(token, tmdb, tx, monitor_cancel).await });
-    c
-}
 
 #[tokio::main]
 async fn main() {
@@ -94,12 +55,12 @@ async fn main() {
 
     let config = Arc::new(Config::load());
     let cancel = CancellationToken::new();
-
     let (media_tx, media_rx) = mpsc::unbounded_channel::<MediaUpdate>();
+
     #[cfg(feature = "tray")]
-    let (tray_tx, mut tray_rx) = mpsc::unbounded_channel::<TrayCommand>();
+    let (tray_tx, tray_rx) = mpsc::unbounded_channel::<TrayCommand>();
     #[cfg(feature = "tray")]
-    let (status_tx, mut status_rx) = mpsc::unbounded_channel::<TrayStatus>();
+    let (status_tx, status_rx) = mpsc::unbounded_channel::<TrayStatus>();
     #[cfg(feature = "tray")]
     let tray = tray::setup(tray_tx, config.plex_token.is_some());
 
@@ -108,89 +69,147 @@ async fn main() {
     let discord = Arc::new(Mutex::new(discord));
 
     #[cfg(feature = "tray")]
-    let mut sse_cancel = config
-        .plex_token
-        .clone()
-        .map(|token| spawn_monitoring(token, config.tmdb_token.clone(), &cancel, &media_tx));
+    let media_task = handle_media(
+        media_rx,
+        Arc::clone(&discord),
+        Arc::clone(&config),
+        status_tx,
+    );
     #[cfg(not(feature = "tray"))]
-    let _sse_cancel = config
+    let media_task = handle_media(media_rx, Arc::clone(&discord), Arc::clone(&config));
+    tokio::spawn(media_task);
+
+    let sse_cancel = config
         .plex_token
         .clone()
         .map(|token| spawn_monitoring(token, config.tmdb_token.clone(), &cancel, &media_tx));
 
     #[cfg(feature = "tray")]
-    tokio::spawn({
-        let discord = Arc::clone(&discord);
-        let config = Arc::clone(&config);
-        async move { handle_media(media_rx, discord, config, status_tx).await }
-    });
+    run_tray(
+        tray, tray_rx, status_rx, sse_cancel, &config, &cancel, &media_tx,
+    )
+    .await;
 
     #[cfg(not(feature = "tray"))]
-    tokio::spawn({
-        let discord = Arc::clone(&discord);
-        let config = Arc::clone(&config);
-        async move { handle_media(media_rx, discord, config).await }
-    });
-
-    #[cfg(feature = "tray")]
     {
-        if tray.is_none() {
-            warn!("Tray unavailable, Ctrl+C to quit");
-            tokio::signal::ctrl_c().await.ok();
-        } else {
-            // Only Windows/macOS need the UI loop pumped from this thread
-            let pump_period = if cfg!(any(windows, target_os = "macos")) {
-                Duration::from_millis(16)
-            } else {
-                Duration::from_secs(3600)
-            };
-            let mut pump = tokio::time::interval(pump_period);
-            let (auth_result_tx, mut auth_result_rx) = mpsc::channel::<Option<String>>(1);
-            let mut auth_in_progress = false;
-            loop {
-                tokio::select! {
-                    biased;
-                    _ = pump.tick() => {
-                        #[cfg(windows)]
-                        pump_messages();
-                        #[cfg(target_os = "macos")]
-                        pump_macos();
-                    }
-                    Some(result) = auth_result_rx.recv() => {
-                        auth_in_progress = false;
-                        match result {
-                            Some(token) => {
-                                if let Some(h) = tray.as_ref() { h.set_auth_text("Reauthenticate"); h.set_status_text(TrayStatus::Idle.as_str()); }
-                                if let Some(old) = sse_cancel.as_ref() { old.cancel(); }
-                                sse_cancel = Some(spawn_monitoring(token, config.tmdb_token.clone(), &cancel, &media_tx));
-                            }
-                            None => {
-                                warn!("Auth failed or timed out");
-                                if sse_cancel.is_none() && let Some(h) = tray.as_ref() { h.set_status_text(TrayStatus::NotAuthenticated.as_str()); }
-                            }
-                        }
-                    }
-                    Some(status) = status_rx.recv() => { if let Some(h) = tray.as_ref() { h.set_status_text(status.as_str()); } }
-                    Some(msg) = tray_rx.recv() => match msg {
-                        TrayCommand::Quit => break,
-                        TrayCommand::Authenticate if !auth_in_progress => {
-                            auth_in_progress = true;
-                            let auth_tx = auth_result_tx.clone();
-                            tokio::spawn(async move { let _ = auth_tx.send(run_auth().await).await; });
-                        }
-                        _ => {}
-                    }
-                }
-            }
-        }
+        let _ = sse_cancel;
+        tokio::signal::ctrl_c().await.ok();
     }
-
-    #[cfg(not(feature = "tray"))]
-    tokio::signal::ctrl_c().await.ok();
 
     cancel.cancel();
     discord.lock().await.disconnect();
     info!("Shutting down");
+}
+
+fn acquire_instance_lock() -> Result<File, String> {
+    let dir = Config::app_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| format!("Cannot create {}: {}", dir.display(), e))?;
+    let path = dir.join("presence-for-plex.lock");
+    let file = File::create(&path)
+        .map_err(|e| format!("Cannot create lock file {}: {}", path.display(), e))?;
+    file.try_lock()
+        .map_err(|_| "Another instance is already running".to_string())?;
+    Ok(file)
+}
+
+fn init_logging() {
+    let path = Config::log_path();
+    std::fs::create_dir_all(path.parent().unwrap()).ok();
+    let level = std::env::var("RUST_LOG")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(LevelFilter::Info);
+    let mut loggers: Vec<Box<dyn simplelog::SharedLogger>> =
+        vec![SimpleLogger::new(level, LogConfig::default())];
+    if let Ok(file) = File::create(&path) {
+        loggers.push(WriteLogger::new(level, LogConfig::default(), file));
+    }
+    let _ = CombinedLogger::init(loggers);
+    info!("Starting Presence for Plex - Log: {}", path.display());
+}
+
+#[cfg(feature = "tray")]
+async fn run_tray(
+    tray: Option<TrayHandle>,
+    mut tray_rx: mpsc::UnboundedReceiver<TrayCommand>,
+    mut status_rx: mpsc::UnboundedReceiver<TrayStatus>,
+    mut sse_cancel: Option<CancellationToken>,
+    config: &Config,
+    cancel: &CancellationToken,
+    media_tx: &mpsc::UnboundedSender<MediaUpdate>,
+) {
+    let Some(tray) = tray else {
+        warn!("Tray unavailable, Ctrl+C to quit");
+        tokio::signal::ctrl_c().await.ok();
+        return;
+    };
+
+    // Only Windows/macOS need the UI loop pumped from this thread
+    let pump_period = if cfg!(any(windows, target_os = "macos")) {
+        Duration::from_millis(16)
+    } else {
+        Duration::from_secs(3600)
+    };
+    let mut pump = tokio::time::interval(pump_period);
+    let (auth_tx, mut auth_rx) = mpsc::channel::<Option<String>>(1);
+    let mut auth_in_progress = false;
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = pump.tick() => {
+                #[cfg(windows)]
+                pump_messages();
+                #[cfg(target_os = "macos")]
+                pump_macos();
+            }
+            Some(token) = auth_rx.recv() => {
+                auth_in_progress = false;
+                match token {
+                    Some(token) => {
+                        tray.set_auth_text("Reauthenticate");
+                        tray.set_status_text(TrayStatus::Idle.as_str());
+                        if let Some(old) = sse_cancel.take() {
+                            old.cancel();
+                        }
+                        sse_cancel =
+                            Some(spawn_monitoring(token, config.tmdb_token.clone(), cancel, media_tx));
+                    }
+                    None => {
+                        warn!("Auth failed or timed out");
+                        if sse_cancel.is_none() {
+                            tray.set_status_text(TrayStatus::NotAuthenticated.as_str());
+                        }
+                    }
+                }
+            }
+            Some(status) = status_rx.recv() => tray.set_status_text(status.as_str()),
+            Some(cmd) = tray_rx.recv() => match cmd {
+                TrayCommand::Quit => break,
+                TrayCommand::Authenticate if !auth_in_progress => {
+                    auth_in_progress = true;
+                    let auth_tx = auth_tx.clone();
+                    tokio::spawn(async move {
+                        let _ = auth_tx.send(run_auth().await).await;
+                    });
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn spawn_monitoring(
+    token: String,
+    tmdb: Option<String>,
+    cancel: &CancellationToken,
+    media_tx: &mpsc::UnboundedSender<MediaUpdate>,
+) -> CancellationToken {
+    let c = cancel.child_token();
+    let monitor_cancel = c.clone();
+    let tx = media_tx.clone();
+    tokio::spawn(async move { begin_monitoring(token, tmdb, tx, monitor_cancel).await });
+    c
 }
 
 async fn begin_monitoring(
@@ -235,47 +254,18 @@ async fn begin_monitoring(
     }
 }
 
-#[cfg(feature = "tray")]
 async fn handle_media(
     mut rx: mpsc::UnboundedReceiver<MediaUpdate>,
     discord: Arc<Mutex<DiscordClient>>,
     config: Arc<Config>,
-    status_tx: mpsc::UnboundedSender<TrayStatus>,
+    #[cfg(feature = "tray")] status_tx: mpsc::UnboundedSender<TrayStatus>,
 ) {
     while let Some(update) = rx.recv().await {
         match update {
             MediaUpdate::Playing(info) => {
+                #[cfg(feature = "tray")]
                 let _ = status_tx.send(TrayStatus::from(info.state));
-                let enabled = match info.media_type {
-                    MediaType::Movie => config.enable_movies,
-                    MediaType::Episode => config.enable_tv_shows,
-                    MediaType::Track => config.enable_music,
-                };
-                if enabled {
-                    let mut d = discord.lock().await;
-                    if !d.is_connected() {
-                        d.connect();
-                    }
-                    d.update(&build_presence(&info, &config));
-                }
-            }
-            MediaUpdate::Stopped => {
-                let _ = status_tx.send(TrayStatus::Idle);
-                discord.lock().await.clear();
-            }
-        }
-    }
-}
 
-#[cfg(not(feature = "tray"))]
-async fn handle_media(
-    mut rx: mpsc::UnboundedReceiver<MediaUpdate>,
-    discord: Arc<Mutex<DiscordClient>>,
-    config: Arc<Config>,
-) {
-    while let Some(update) = rx.recv().await {
-        match update {
-            MediaUpdate::Playing(info) => {
                 let enabled = match info.media_type {
                     MediaType::Movie => config.enable_movies,
                     MediaType::Episode => config.enable_tv_shows,
@@ -290,6 +280,9 @@ async fn handle_media(
                 }
             }
             MediaUpdate::Stopped => {
+                #[cfg(feature = "tray")]
+                let _ = status_tx.send(TrayStatus::Idle);
+
                 discord.lock().await.clear();
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,15 +14,15 @@ use discord::DiscordClient;
 use fs2::FileExt;
 use log::{error, info, warn};
 use metadata::MetadataEnricher;
-use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
-use plex_account::{PlexAccount, APP_NAME};
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
+use plex_account::{APP_NAME, PlexAccount};
 use plex_server::{MediaType, MediaUpdate, PlexServer};
 use presence::build_presence;
 use simplelog::{CombinedLogger, Config as LogConfig, LevelFilter, SimpleLogger, WriteLogger};
 use std::fs::File;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{Mutex, mpsc};
 use tokio_util::sync::CancellationToken;
 #[cfg(feature = "tray")]
 use tray::{TrayCommand, TrayStatus};
@@ -36,16 +36,22 @@ fn acquire_instance_lock() -> Result<File, String> {
     let dir = Config::app_dir();
     std::fs::create_dir_all(&dir).map_err(|e| format!("Cannot create {}: {}", dir.display(), e))?;
     let path = dir.join("presence-for-plex.lock");
-    let file = File::create(&path).map_err(|e| format!("Cannot create lock file {}: {}", path.display(), e))?;
-    file.try_lock_exclusive().map_err(|_| "Another instance is already running".to_string())?;
+    let file = File::create(&path)
+        .map_err(|e| format!("Cannot create lock file {}: {}", path.display(), e))?;
+    file.try_lock_exclusive()
+        .map_err(|_| "Another instance is already running".to_string())?;
     Ok(file)
 }
 
 fn init_logging() {
     let path = Config::log_path();
     std::fs::create_dir_all(path.parent().unwrap()).ok();
-    let level = std::env::var("RUST_LOG").ok().and_then(|s| s.parse().ok()).unwrap_or(LevelFilter::Info);
-    let mut loggers: Vec<Box<dyn simplelog::SharedLogger>> = vec![SimpleLogger::new(level, LogConfig::default())];
+    let level = std::env::var("RUST_LOG")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(LevelFilter::Info);
+    let mut loggers: Vec<Box<dyn simplelog::SharedLogger>> =
+        vec![SimpleLogger::new(level, LogConfig::default())];
     if let Ok(file) = File::create(&path) {
         loggers.push(WriteLogger::new(level, LogConfig::default(), file));
     }
@@ -53,7 +59,12 @@ fn init_logging() {
     info!("Starting Presence for Plex - Log: {}", path.display());
 }
 
-fn spawn_monitoring(token: String, tmdb: Option<String>, cancel: &CancellationToken, media_tx: &mpsc::UnboundedSender<MediaUpdate>) -> CancellationToken {
+fn spawn_monitoring(
+    token: String,
+    tmdb: Option<String>,
+    cancel: &CancellationToken,
+    media_tx: &mpsc::UnboundedSender<MediaUpdate>,
+) -> CancellationToken {
     let c = cancel.child_token();
     let monitor_cancel = c.clone();
     let tx = media_tx.clone();
@@ -65,7 +76,10 @@ fn spawn_monitoring(token: String, tmdb: Option<String>, cancel: &CancellationTo
 async fn main() {
     let _lock = match acquire_instance_lock() {
         Ok(f) => f,
-        Err(e) => { eprintln!("{}", e); return; }
+        Err(e) => {
+            eprintln!("{}", e);
+            return;
+        }
     };
 
     init_logging();
@@ -94,9 +108,15 @@ async fn main() {
     let discord = Arc::new(Mutex::new(discord));
 
     #[cfg(feature = "tray")]
-    let mut sse_cancel = config.plex_token.clone().map(|token| spawn_monitoring(token, config.tmdb_token.clone(), &cancel, &media_tx));
+    let mut sse_cancel = config
+        .plex_token
+        .clone()
+        .map(|token| spawn_monitoring(token, config.tmdb_token.clone(), &cancel, &media_tx));
     #[cfg(not(feature = "tray"))]
-    let _sse_cancel = config.plex_token.clone().map(|token| spawn_monitoring(token, config.tmdb_token.clone(), &cancel, &media_tx));
+    let _sse_cancel = config
+        .plex_token
+        .clone()
+        .map(|token| spawn_monitoring(token, config.tmdb_token.clone(), &cancel, &media_tx));
 
     #[cfg(feature = "tray")]
     tokio::spawn({
@@ -119,7 +139,11 @@ async fn main() {
             tokio::signal::ctrl_c().await.ok();
         } else {
             // Only Windows/macOS need the UI loop pumped from this thread
-            let pump_period = if cfg!(any(windows, target_os = "macos")) { Duration::from_millis(16) } else { Duration::from_secs(3600) };
+            let pump_period = if cfg!(any(windows, target_os = "macos")) {
+                Duration::from_millis(16)
+            } else {
+                Duration::from_secs(3600)
+            };
             let mut pump = tokio::time::interval(pump_period);
             let (auth_result_tx, mut auth_result_rx) = mpsc::channel::<Option<String>>(1);
             let mut auth_in_progress = false;
@@ -169,7 +193,12 @@ async fn main() {
     info!("Shutting down");
 }
 
-async fn begin_monitoring(token: String, tmdb: Option<String>, tx: mpsc::UnboundedSender<MediaUpdate>, cancel: CancellationToken) {
+async fn begin_monitoring(
+    token: String,
+    tmdb: Option<String>,
+    tx: mpsc::UnboundedSender<MediaUpdate>,
+    cancel: CancellationToken,
+) {
     let enricher = Arc::new(MetadataEnricher::new(tmdb));
     let mut account = PlexAccount::new();
 
@@ -193,7 +222,9 @@ async fn begin_monitoring(token: String, tmdb: Option<String>, tx: mpsc::Unbound
 
     let username = account.username().map(String::from);
     for srv in servers {
-        let Some(access) = srv.access_token else { continue };
+        let Some(access) = srv.access_token else {
+            continue;
+        };
         let server = PlexServer::new(srv.name, srv.connections, access, username.clone());
         let tx = tx.clone();
         let enricher = Arc::clone(&enricher);
@@ -205,43 +236,71 @@ async fn begin_monitoring(token: String, tmdb: Option<String>, tx: mpsc::Unbound
 }
 
 #[cfg(feature = "tray")]
-async fn handle_media(mut rx: mpsc::UnboundedReceiver<MediaUpdate>, discord: Arc<Mutex<DiscordClient>>, config: Arc<Config>, status_tx: mpsc::UnboundedSender<TrayStatus>) {
+async fn handle_media(
+    mut rx: mpsc::UnboundedReceiver<MediaUpdate>,
+    discord: Arc<Mutex<DiscordClient>>,
+    config: Arc<Config>,
+    status_tx: mpsc::UnboundedSender<TrayStatus>,
+) {
     while let Some(update) = rx.recv().await {
         match update {
             MediaUpdate::Playing(info) => {
                 let _ = status_tx.send(TrayStatus::from(info.state));
-                let enabled = match info.media_type { MediaType::Movie => config.enable_movies, MediaType::Episode => config.enable_tv_shows, MediaType::Track => config.enable_music };
+                let enabled = match info.media_type {
+                    MediaType::Movie => config.enable_movies,
+                    MediaType::Episode => config.enable_tv_shows,
+                    MediaType::Track => config.enable_music,
+                };
                 if enabled {
                     let mut d = discord.lock().await;
-                    if !d.is_connected() { d.connect(); }
+                    if !d.is_connected() {
+                        d.connect();
+                    }
                     d.update(&build_presence(&info, &config));
                 }
             }
-            MediaUpdate::Stopped => { let _ = status_tx.send(TrayStatus::Idle); discord.lock().await.clear(); }
+            MediaUpdate::Stopped => {
+                let _ = status_tx.send(TrayStatus::Idle);
+                discord.lock().await.clear();
+            }
         }
     }
 }
 
 #[cfg(not(feature = "tray"))]
-async fn handle_media(mut rx: mpsc::UnboundedReceiver<MediaUpdate>, discord: Arc<Mutex<DiscordClient>>, config: Arc<Config>) {
+async fn handle_media(
+    mut rx: mpsc::UnboundedReceiver<MediaUpdate>,
+    discord: Arc<Mutex<DiscordClient>>,
+    config: Arc<Config>,
+) {
     while let Some(update) = rx.recv().await {
         match update {
             MediaUpdate::Playing(info) => {
-                let enabled = match info.media_type { MediaType::Movie => config.enable_movies, MediaType::Episode => config.enable_tv_shows, MediaType::Track => config.enable_music };
+                let enabled = match info.media_type {
+                    MediaType::Movie => config.enable_movies,
+                    MediaType::Episode => config.enable_tv_shows,
+                    MediaType::Track => config.enable_music,
+                };
                 if enabled {
                     let mut d = discord.lock().await;
-                    if !d.is_connected() { d.connect(); }
+                    if !d.is_connected() {
+                        d.connect();
+                    }
                     d.update(&build_presence(&info, &config));
                 }
             }
-            MediaUpdate::Stopped => { discord.lock().await.clear(); }
+            MediaUpdate::Stopped => {
+                discord.lock().await.clear();
+            }
         }
     }
 }
 
 #[cfg(windows)]
 fn pump_messages() {
-    use windows_sys::Win32::UI::WindowsAndMessaging::{DispatchMessageW, PeekMessageW, TranslateMessage, MSG, PM_REMOVE};
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        DispatchMessageW, MSG, PM_REMOVE, PeekMessageW, TranslateMessage,
+    };
     unsafe {
         let mut msg: MSG = std::mem::zeroed();
         while PeekMessageW(&mut msg, std::ptr::null_mut(), 0, 0, PM_REMOVE) != 0 {
@@ -261,17 +320,32 @@ async fn run_auth() -> Option<String> {
     info!("Starting Plex auth");
     let account = PlexAccount::new();
     let (pin_id, code) = account.request_pin().await?;
-    let url = format!("https://app.plex.tv/auth#?clientID={}&code={}&context%5Bdevice%5D%5Bproduct%5D=Presence%20for%20Plex", utf8_percent_encode(APP_NAME, NON_ALPHANUMERIC), utf8_percent_encode(&code, NON_ALPHANUMERIC));
+    let url = format!(
+        "https://app.plex.tv/auth#?clientID={}&code={}&context%5Bdevice%5D%5Bproduct%5D=Presence%20for%20Plex",
+        utf8_percent_encode(APP_NAME, NON_ALPHANUMERIC),
+        utf8_percent_encode(&code, NON_ALPHANUMERIC)
+    );
     println!("Open to authenticate:\n{}", url);
-    if let Err(e) = open::that(&url) { warn!("Browser failed: {}", e); }
+    if let Err(e) = open::that(&url) {
+        warn!("Browser failed: {}", e);
+    }
 
     let token = tokio::time::timeout(AUTH_TIMEOUT, async {
-        loop { tokio::time::sleep(AUTH_POLL_INTERVAL).await; if let Some(t) = account.check_pin(pin_id).await { return t; } }
-    }).await.ok()?;
+        loop {
+            tokio::time::sleep(AUTH_POLL_INTERVAL).await;
+            if let Some(t) = account.check_pin(pin_id).await {
+                return t;
+            }
+        }
+    })
+    .await
+    .ok()?;
 
     let mut cfg = Config::load();
     cfg.plex_token = Some(token.clone());
-    if let Err(e) = cfg.save() { error!("Config save failed: {}", e); }
+    if let Err(e) = cfg.save() {
+        error!("Config save failed: {}", e);
+    }
     info!("Auth complete");
     Some(token)
 }

--- a/src/media.rs
+++ b/src/media.rs
@@ -1,0 +1,70 @@
+#[derive(Debug, Clone)]
+pub enum MediaUpdate {
+    Playing(Box<MediaInfo>),
+    Stopped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum MediaType {
+    Movie,
+    Episode,
+    Track,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PlaybackState {
+    Playing,
+    Paused,
+    Buffering,
+}
+
+#[derive(Debug, Clone)]
+pub struct MediaInfo {
+    pub title: String,
+    pub media_type: MediaType,
+    pub show_name: Option<String>,
+    pub season: Option<u32>,
+    pub episode: Option<u32>,
+    pub artist: Option<String>,
+    pub album: Option<String>,
+    pub year: Option<u32>,
+    pub genres: Vec<String>,
+    pub duration_ms: u64,
+    pub view_offset_ms: u64,
+    pub state: PlaybackState,
+    pub imdb_id: Option<String>,
+    pub tmdb_id: Option<String>,
+    pub mal_id: Option<String>,
+    pub art_url: Option<String>,
+    pub rating_key: Option<String>,
+    // Plex library keys for follow-up metadata requests
+    pub(crate) grandparent_key: Option<String>,
+    pub(crate) key: Option<String>,
+}
+
+#[cfg(test)]
+impl MediaInfo {
+    pub fn test_stub(media_type: MediaType) -> Self {
+        Self {
+            title: "Title".into(),
+            media_type,
+            show_name: None,
+            season: None,
+            episode: None,
+            artist: None,
+            album: None,
+            year: None,
+            genres: Vec::new(),
+            duration_ms: 0,
+            view_offset_ms: 0,
+            state: PlaybackState::Playing,
+            imdb_id: None,
+            tmdb_id: None,
+            mal_id: None,
+            art_url: None,
+            rating_key: None,
+            grandparent_key: None,
+            key: None,
+        }
+    }
+}

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
-use crate::plex_server::{MediaInfo, MediaType};
+use crate::media::{MediaInfo, MediaType};
 
 const TMDB_API: &str = "https://api.themoviedb.org/3";
 const TMDB_IMAGE_BASE: &str = "https://image.tmdb.org/t/p/w500";
@@ -23,11 +23,59 @@ struct CacheEntry {
     timestamp: Instant,
 }
 
+struct Cache(RwLock<HashMap<String, CacheEntry>>);
+
+impl Cache {
+    fn new() -> Self {
+        Self(RwLock::new(HashMap::new()))
+    }
+
+    // Outer None = not cached, inner None = cached miss
+    fn get(&self, key: &str) -> Option<Option<String>> {
+        self.0
+            .read()
+            .unwrap()
+            .get(key)
+            .filter(|e| e.timestamp.elapsed() < CACHE_TTL)
+            .map(|e| e.value.clone())
+    }
+
+    fn insert(&self, key: &str, value: Option<String>) {
+        self.0.write().unwrap().insert(
+            key.to_string(),
+            CacheEntry {
+                value,
+                timestamp: Instant::now(),
+            },
+        );
+    }
+
+    fn prune(&self) {
+        if self.0.read().unwrap().len() < CACHE_CLEANUP_THRESHOLD {
+            return;
+        }
+        let mut entries = self.0.write().unwrap();
+        entries.retain(|_, e| e.timestamp.elapsed() < CACHE_TTL);
+        if entries.len() >= CACHE_CLEANUP_THRESHOLD {
+            // Still full, evict the older half
+            let mut stamps: Vec<Instant> = entries.values().map(|e| e.timestamp).collect();
+            stamps.sort();
+            let cutoff = stamps[stamps.len() / 2];
+            entries.retain(|_, e| e.timestamp > cutoff);
+        }
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.0.read().unwrap().len()
+    }
+}
+
 pub struct MetadataEnricher {
     client: Client,
     tmdb_token: String,
-    art_cache: RwLock<HashMap<String, CacheEntry>>,
-    mal_cache: RwLock<HashMap<String, CacheEntry>>,
+    art_cache: Cache,
+    mal_cache: Cache,
 }
 
 impl MetadataEnricher {
@@ -39,27 +87,23 @@ impl MetadataEnricher {
                 .build()
                 .expect("HTTP client"),
             tmdb_token: tmdb_token.unwrap_or_else(|| DEFAULT_TMDB_TOKEN.to_string()),
-            art_cache: RwLock::new(HashMap::new()),
-            mal_cache: RwLock::new(HashMap::new()),
+            art_cache: Cache::new(),
+            mal_cache: Cache::new(),
         }
     }
 
     pub async fn enrich(&self, info: &mut MediaInfo) {
-        self.cleanup_cache();
-        let key = self.cache_key(info);
+        self.art_cache.prune();
+        self.mal_cache.prune();
 
-        let cached = self.get_art_cached(&key);
-        if let Some(Some(url)) = &cached {
-            info.art_url = Some(url.clone());
-        }
-
-        // Fetch artwork if not cached
-        if cached.is_none() {
-            if info.media_type == MediaType::Track {
+        let key = cache_key(info);
+        match self.art_cache.get(&key) {
+            Some(Some(url)) => info.art_url = Some(url),
+            Some(None) => {}
+            None if info.media_type == MediaType::Track => {
                 self.try_musicbrainz(info, &key).await;
-            } else {
-                self.try_tmdb(info, &key).await;
             }
+            None => self.try_tmdb(info, &key).await,
         }
 
         // For anime, fetch MAL ID for the link ("animation" alone is not anime)
@@ -69,35 +113,9 @@ impl MetadataEnricher {
         }
     }
 
-    fn cache_key(&self, info: &MediaInfo) -> String {
-        match info.media_type {
-            MediaType::Track => format!(
-                "mb:{}:{}",
-                info.artist.as_deref().unwrap_or(""),
-                info.album.as_deref().unwrap_or("")
-            ),
-            MediaType::Episode => info
-                .tmdb_id
-                .as_ref()
-                .map(|id| format!("tmdb:{}:s{}", id, info.season.unwrap_or(1)))
-                .unwrap_or_else(|| {
-                    format!(
-                        "title:{}:s{}",
-                        info.show_name.as_ref().unwrap_or(&info.title),
-                        info.season.unwrap_or(1)
-                    )
-                }),
-            _ => info
-                .tmdb_id
-                .as_ref()
-                .map(|id| format!("tmdb:{}", id))
-                .unwrap_or_else(|| format!("title:{}:{}", info.title, info.year.unwrap_or(0))),
-        }
-    }
-
-    async fn try_tmdb(&self, info: &mut MediaInfo, key: &str) -> bool {
+    async fn try_tmdb(&self, info: &mut MediaInfo, key: &str) {
         let Some(ref tmdb_id) = info.tmdb_id else {
-            return false;
+            return;
         };
 
         let result = match info.media_type {
@@ -106,7 +124,6 @@ impl MetadataEnricher {
                     .await
             }
             MediaType::Episode => {
-                // Try season-specific artwork first, fall back to show artwork
                 let season = info.season.unwrap_or(1);
                 match self
                     .fetch_tmdb_images(&format!("/tv/{}/season/{}/images", tmdb_id, season))
@@ -119,16 +136,13 @@ impl MetadataEnricher {
                     }
                 }
             }
-            _ => return false,
+            MediaType::Track => return,
         };
 
-        self.set_art_cached(key, result.clone());
+        self.art_cache.insert(key, result.clone());
         if let Some(url) = result {
             info!("TMDB artwork: {}", url);
             info.art_url = Some(url);
-            true
-        } else {
-            false
         }
     }
 
@@ -152,7 +166,7 @@ impl MetadataEnricher {
         let title = info.show_name.as_ref().unwrap_or(&info.title);
         let cache_key = format!("{}_{}", title, info.year.unwrap_or(0));
 
-        if let Some(cached) = self.get_mal_cached(&cache_key) {
+        if let Some(cached) = self.mal_cache.get(&cache_key) {
             info.mal_id = cached;
             return;
         }
@@ -170,7 +184,7 @@ impl MetadataEnricher {
         }
         .await;
 
-        self.set_mal_cached(&cache_key, mal_id.clone());
+        self.mal_cache.insert(&cache_key, mal_id.clone());
         if let Some(id) = mal_id {
             info!("MAL ID: {}", id);
             info.mal_id = Some(id);
@@ -179,7 +193,7 @@ impl MetadataEnricher {
 
     async fn try_musicbrainz(&self, info: &mut MediaInfo, key: &str) {
         let (Some(artist), Some(album)) = (&info.artist, &info.album) else {
-            self.set_art_cached(key, None);
+            self.art_cache.insert(key, None);
             return;
         };
         let query = format!(
@@ -211,7 +225,7 @@ impl MetadataEnricher {
         .await;
 
         let Some(mbid) = mbid else {
-            self.set_art_cached(key, None);
+            self.art_cache.insert(key, None);
             return;
         };
         let cover_url = format!("{}/release/{}/front", COVERART_API, mbid);
@@ -226,64 +240,37 @@ impl MetadataEnricher {
             .unwrap_or(false);
 
         let result = if exists { Some(cover_url) } else { None };
-        self.set_art_cached(key, result.clone());
+        self.art_cache.insert(key, result.clone());
         if let Some(url) = result {
             info!("MusicBrainz artwork: {}", url);
             info.art_url = Some(url);
         }
     }
+}
 
-    fn cleanup_cache(&self) {
-        for cache in [&self.art_cache, &self.mal_cache] {
-            if cache.read().unwrap().len() < CACHE_CLEANUP_THRESHOLD {
-                continue;
-            }
-            let mut c = cache.write().unwrap();
-            c.retain(|_, e| e.timestamp.elapsed() < CACHE_TTL);
-            if c.len() >= CACHE_CLEANUP_THRESHOLD {
-                // Still full, evict the older half
-                let mut stamps: Vec<Instant> = c.values().map(|e| e.timestamp).collect();
-                stamps.sort();
-                let cutoff = stamps[stamps.len() / 2];
-                c.retain(|_, e| e.timestamp > cutoff);
-            }
-        }
-    }
-
-    fn get_art_cached(&self, key: &str) -> Option<Option<String>> {
-        let cache = self.art_cache.read().unwrap();
-        cache
-            .get(key)
-            .filter(|e| e.timestamp.elapsed() < CACHE_TTL)
-            .map(|e| e.value.clone())
-    }
-
-    fn set_art_cached(&self, key: &str, value: Option<String>) {
-        self.art_cache.write().unwrap().insert(
-            key.to_string(),
-            CacheEntry {
-                value,
-                timestamp: Instant::now(),
-            },
-        );
-    }
-
-    fn get_mal_cached(&self, key: &str) -> Option<Option<String>> {
-        let cache = self.mal_cache.read().unwrap();
-        cache
-            .get(key)
-            .filter(|e| e.timestamp.elapsed() < CACHE_TTL)
-            .map(|e| e.value.clone())
-    }
-
-    fn set_mal_cached(&self, key: &str, value: Option<String>) {
-        self.mal_cache.write().unwrap().insert(
-            key.to_string(),
-            CacheEntry {
-                value,
-                timestamp: Instant::now(),
-            },
-        );
+fn cache_key(info: &MediaInfo) -> String {
+    match info.media_type {
+        MediaType::Track => format!(
+            "mb:{}:{}",
+            info.artist.as_deref().unwrap_or(""),
+            info.album.as_deref().unwrap_or("")
+        ),
+        MediaType::Episode => info
+            .tmdb_id
+            .as_ref()
+            .map(|id| format!("tmdb:{}:s{}", id, info.season.unwrap_or(1)))
+            .unwrap_or_else(|| {
+                format!(
+                    "title:{}:s{}",
+                    info.show_name.as_ref().unwrap_or(&info.title),
+                    info.season.unwrap_or(1)
+                )
+            }),
+        MediaType::Movie => info
+            .tmdb_id
+            .as_ref()
+            .map(|id| format!("tmdb:{}", id))
+            .unwrap_or_else(|| format!("title:{}:{}", info.title, info.year.unwrap_or(0))),
     }
 }
 
@@ -320,16 +307,12 @@ struct MbRelease {
 mod tests {
     use super::*;
 
-    fn enricher() -> MetadataEnricher {
-        MetadataEnricher::new(None)
-    }
-
     #[test]
     fn cache_key_for_track_uses_artist_and_album() {
         let mut info = MediaInfo::test_stub(MediaType::Track);
         info.artist = Some("Artist".into());
         info.album = Some("Album".into());
-        assert_eq!(enricher().cache_key(&info), "mb:Artist:Album");
+        assert_eq!(cache_key(&info), "mb:Artist:Album");
     }
 
     #[test]
@@ -337,14 +320,14 @@ mod tests {
         let mut info = MediaInfo::test_stub(MediaType::Episode);
         info.tmdb_id = Some("42".into());
         info.season = Some(3);
-        assert_eq!(enricher().cache_key(&info), "tmdb:42:s3");
+        assert_eq!(cache_key(&info), "tmdb:42:s3");
     }
 
     #[test]
     fn cache_key_for_episode_falls_back_to_show_name() {
         let mut info = MediaInfo::test_stub(MediaType::Episode);
         info.show_name = Some("Some Show".into());
-        assert_eq!(enricher().cache_key(&info), "title:Some Show:s1");
+        assert_eq!(cache_key(&info), "title:Some Show:s1");
     }
 
     #[test]
@@ -352,27 +335,27 @@ mod tests {
         let mut info = MediaInfo::test_stub(MediaType::Movie);
         info.title = "Some Movie".into();
         info.year = Some(1999);
-        assert_eq!(enricher().cache_key(&info), "title:Some Movie:1999");
+        assert_eq!(cache_key(&info), "title:Some Movie:1999");
     }
 
     #[test]
-    fn art_cache_stores_and_expires_nothing_when_fresh() {
-        let e = enricher();
-        e.set_art_cached("k", Some("url".into()));
-        assert_eq!(e.get_art_cached("k"), Some(Some("url".into())));
+    fn cache_distinguishes_misses_from_absent_entries() {
+        let cache = Cache::new();
+        cache.insert("k", Some("url".into()));
+        assert_eq!(cache.get("k"), Some(Some("url".into())));
         // Negative results are cached too
-        e.set_art_cached("miss", None);
-        assert_eq!(e.get_art_cached("miss"), Some(None));
-        assert_eq!(e.get_art_cached("absent"), None);
+        cache.insert("miss", None);
+        assert_eq!(cache.get("miss"), Some(None));
+        assert_eq!(cache.get("absent"), None);
     }
 
     #[test]
-    fn cleanup_caps_cache_size_even_when_entries_are_fresh() {
-        let e = enricher();
+    fn prune_caps_cache_size_even_when_entries_are_fresh() {
+        let cache = Cache::new();
         for i in 0..CACHE_CLEANUP_THRESHOLD {
-            e.set_art_cached(&format!("k{}", i), None);
+            cache.insert(&format!("k{}", i), None);
         }
-        e.cleanup_cache();
-        assert!(e.art_cache.read().unwrap().len() < CACHE_CLEANUP_THRESHOLD);
+        cache.prune();
+        assert!(cache.len() < CACHE_CLEANUP_THRESHOLD);
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,5 +1,5 @@
 use log::info;
-use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use reqwest::Client;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -33,7 +33,11 @@ pub struct MetadataEnricher {
 impl MetadataEnricher {
     pub fn new(tmdb_token: Option<String>) -> Self {
         Self {
-            client: Client::builder().user_agent("PresenceForPlex/1.0").timeout(Duration::from_secs(10)).build().expect("HTTP client"),
+            client: Client::builder()
+                .user_agent("PresenceForPlex/1.0")
+                .timeout(Duration::from_secs(10))
+                .build()
+                .expect("HTTP client"),
             tmdb_token: tmdb_token.unwrap_or_else(|| DEFAULT_TMDB_TOKEN.to_string()),
             art_cache: RwLock::new(HashMap::new()),
             mal_cache: RwLock::new(HashMap::new()),
@@ -67,43 +71,81 @@ impl MetadataEnricher {
 
     fn cache_key(&self, info: &MediaInfo) -> String {
         match info.media_type {
-            MediaType::Track => format!("mb:{}:{}", info.artist.as_deref().unwrap_or(""), info.album.as_deref().unwrap_or("")),
-            MediaType::Episode => info.tmdb_id.as_ref()
+            MediaType::Track => format!(
+                "mb:{}:{}",
+                info.artist.as_deref().unwrap_or(""),
+                info.album.as_deref().unwrap_or("")
+            ),
+            MediaType::Episode => info
+                .tmdb_id
+                .as_ref()
                 .map(|id| format!("tmdb:{}:s{}", id, info.season.unwrap_or(1)))
-                .unwrap_or_else(|| format!("title:{}:s{}", info.show_name.as_ref().unwrap_or(&info.title), info.season.unwrap_or(1))),
-            _ => info.tmdb_id.as_ref()
+                .unwrap_or_else(|| {
+                    format!(
+                        "title:{}:s{}",
+                        info.show_name.as_ref().unwrap_or(&info.title),
+                        info.season.unwrap_or(1)
+                    )
+                }),
+            _ => info
+                .tmdb_id
+                .as_ref()
                 .map(|id| format!("tmdb:{}", id))
                 .unwrap_or_else(|| format!("title:{}:{}", info.title, info.year.unwrap_or(0))),
         }
     }
 
     async fn try_tmdb(&self, info: &mut MediaInfo, key: &str) -> bool {
-        let Some(ref tmdb_id) = info.tmdb_id else { return false };
+        let Some(ref tmdb_id) = info.tmdb_id else {
+            return false;
+        };
 
         let result = match info.media_type {
-            MediaType::Movie => self.fetch_tmdb_images(&format!("/movie/{}/images", tmdb_id)).await,
+            MediaType::Movie => {
+                self.fetch_tmdb_images(&format!("/movie/{}/images", tmdb_id))
+                    .await
+            }
             MediaType::Episode => {
                 // Try season-specific artwork first, fall back to show artwork
                 let season = info.season.unwrap_or(1);
-                match self.fetch_tmdb_images(&format!("/tv/{}/season/{}/images", tmdb_id, season)).await {
+                match self
+                    .fetch_tmdb_images(&format!("/tv/{}/season/{}/images", tmdb_id, season))
+                    .await
+                {
                     Some(url) => Some(url),
-                    None => self.fetch_tmdb_images(&format!("/tv/{}/images", tmdb_id)).await,
+                    None => {
+                        self.fetch_tmdb_images(&format!("/tv/{}/images", tmdb_id))
+                            .await
+                    }
                 }
             }
             _ => return false,
         };
 
         self.set_art_cached(key, result.clone());
-        if let Some(url) = result { info!("TMDB artwork: {}", url); info.art_url = Some(url); true } else { false }
+        if let Some(url) = result {
+            info!("TMDB artwork: {}", url);
+            info.art_url = Some(url);
+            true
+        } else {
+            false
+        }
     }
 
     async fn fetch_tmdb_images(&self, path: &str) -> Option<String> {
-        let resp = self.client
+        let resp = self
+            .client
             .get(format!("{}{}", TMDB_API, path))
             .header("Authorization", format!("Bearer {}", self.tmdb_token))
-            .send().await.ok()?;
+            .send()
+            .await
+            .ok()?;
         let images: TmdbImages = resp.json().await.ok()?;
-        images.posters.first().or(images.backdrops.first()).map(|i| format!("{}{}", TMDB_IMAGE_BASE, i.file_path))
+        images
+            .posters
+            .first()
+            .or(images.backdrops.first())
+            .map(|i| format!("{}{}", TMDB_IMAGE_BASE, i.file_path))
     }
 
     async fn fetch_mal_id(&self, info: &mut MediaInfo) {
@@ -115,41 +157,80 @@ impl MetadataEnricher {
             return;
         }
 
-        let url = format!("{}?q={}&limit=1", JIKAN_API, utf8_percent_encode(title, NON_ALPHANUMERIC));
+        let url = format!(
+            "{}?q={}&limit=1",
+            JIKAN_API,
+            utf8_percent_encode(title, NON_ALPHANUMERIC)
+        );
 
         let mal_id = async {
             let resp = self.client.get(&url).send().await.ok()?;
             let data: JikanResponse = resp.json().await.ok()?;
             Some(data.data.first()?.mal_id.to_string())
-        }.await;
+        }
+        .await;
 
         self.set_mal_cached(&cache_key, mal_id.clone());
-        if let Some(id) = mal_id { info!("MAL ID: {}", id); info.mal_id = Some(id); }
+        if let Some(id) = mal_id {
+            info!("MAL ID: {}", id);
+            info.mal_id = Some(id);
+        }
     }
 
     async fn try_musicbrainz(&self, info: &mut MediaInfo, key: &str) {
-        let (Some(artist), Some(album)) = (&info.artist, &info.album) else { self.set_art_cached(key, None); return };
-        let query = format!("artist:\"{}\" AND release:\"{}\"", artist.replace('"', ""), album.replace('"', ""));
-        let ua = concat!("PresenceForPlex/", env!("CARGO_PKG_VERSION"), " (https://github.com/abarnes6/presence-for-plex)");
+        let (Some(artist), Some(album)) = (&info.artist, &info.album) else {
+            self.set_art_cached(key, None);
+            return;
+        };
+        let query = format!(
+            "artist:\"{}\" AND release:\"{}\"",
+            artist.replace('"', ""),
+            album.replace('"', "")
+        );
+        let ua = concat!(
+            "PresenceForPlex/",
+            env!("CARGO_PKG_VERSION"),
+            " (https://github.com/abarnes6/presence-for-plex)"
+        );
 
         let mbid = async {
-            let resp = self.client
-                .get(format!("{}/release?query={}&fmt=json&limit=1", MUSICBRAINZ_API, utf8_percent_encode(&query, NON_ALPHANUMERIC)))
+            let resp = self
+                .client
+                .get(format!(
+                    "{}/release?query={}&fmt=json&limit=1",
+                    MUSICBRAINZ_API,
+                    utf8_percent_encode(&query, NON_ALPHANUMERIC)
+                ))
                 .header("User-Agent", ua)
-                .send().await.ok()?;
+                .send()
+                .await
+                .ok()?;
             let data: MbSearch = resp.json().await.ok()?;
             data.releases.first().map(|rel| rel.id.clone())
-        }.await;
+        }
+        .await;
 
-        let Some(mbid) = mbid else { self.set_art_cached(key, None); return };
+        let Some(mbid) = mbid else {
+            self.set_art_cached(key, None);
+            return;
+        };
         let cover_url = format!("{}/release/{}/front", COVERART_API, mbid);
 
-        let exists = self.client.head(&cover_url).header("User-Agent", ua).send().await
-            .map(|r| r.status().is_success() || r.status().is_redirection()).unwrap_or(false);
+        let exists = self
+            .client
+            .head(&cover_url)
+            .header("User-Agent", ua)
+            .send()
+            .await
+            .map(|r| r.status().is_success() || r.status().is_redirection())
+            .unwrap_or(false);
 
         let result = if exists { Some(cover_url) } else { None };
         self.set_art_cached(key, result.clone());
-        if let Some(url) = result { info!("MusicBrainz artwork: {}", url); info.art_url = Some(url); }
+        if let Some(url) = result {
+            info!("MusicBrainz artwork: {}", url);
+            info.art_url = Some(url);
+        }
     }
 
     fn cleanup_cache(&self) {
@@ -171,35 +252,69 @@ impl MetadataEnricher {
 
     fn get_art_cached(&self, key: &str) -> Option<Option<String>> {
         let cache = self.art_cache.read().unwrap();
-        cache.get(key).filter(|e| e.timestamp.elapsed() < CACHE_TTL).map(|e| e.value.clone())
+        cache
+            .get(key)
+            .filter(|e| e.timestamp.elapsed() < CACHE_TTL)
+            .map(|e| e.value.clone())
     }
 
     fn set_art_cached(&self, key: &str, value: Option<String>) {
-        self.art_cache.write().unwrap().insert(key.to_string(), CacheEntry { value, timestamp: Instant::now() });
+        self.art_cache.write().unwrap().insert(
+            key.to_string(),
+            CacheEntry {
+                value,
+                timestamp: Instant::now(),
+            },
+        );
     }
 
     fn get_mal_cached(&self, key: &str) -> Option<Option<String>> {
         let cache = self.mal_cache.read().unwrap();
-        cache.get(key).filter(|e| e.timestamp.elapsed() < CACHE_TTL).map(|e| e.value.clone())
+        cache
+            .get(key)
+            .filter(|e| e.timestamp.elapsed() < CACHE_TTL)
+            .map(|e| e.value.clone())
     }
 
     fn set_mal_cached(&self, key: &str, value: Option<String>) {
-        self.mal_cache.write().unwrap().insert(key.to_string(), CacheEntry { value, timestamp: Instant::now() });
+        self.mal_cache.write().unwrap().insert(
+            key.to_string(),
+            CacheEntry {
+                value,
+                timestamp: Instant::now(),
+            },
+        );
     }
 }
 
 #[derive(Deserialize)]
-struct TmdbImages { #[serde(default)] posters: Vec<TmdbImage>, #[serde(default)] backdrops: Vec<TmdbImage> }
+struct TmdbImages {
+    #[serde(default)]
+    posters: Vec<TmdbImage>,
+    #[serde(default)]
+    backdrops: Vec<TmdbImage>,
+}
 #[derive(Deserialize)]
-struct TmdbImage { file_path: String }
+struct TmdbImage {
+    file_path: String,
+}
 #[derive(Deserialize)]
-struct JikanResponse { #[serde(default)] data: Vec<JikanAnime> }
+struct JikanResponse {
+    #[serde(default)]
+    data: Vec<JikanAnime>,
+}
 #[derive(Deserialize)]
-struct JikanAnime { mal_id: u64 }
+struct JikanAnime {
+    mal_id: u64,
+}
 #[derive(Deserialize)]
-struct MbSearch { releases: Vec<MbRelease> }
+struct MbSearch {
+    releases: Vec<MbRelease>,
+}
 #[derive(Deserialize)]
-struct MbRelease { id: String }
+struct MbRelease {
+    id: String,
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/plex_account.rs
+++ b/src/plex_account.rs
@@ -20,21 +20,39 @@ pub struct ServerInfo {
 }
 
 #[derive(Debug, Clone)]
-pub struct ServerConnection { pub uri: String }
+pub struct ServerConnection {
+    pub uri: String,
+}
 
 impl PlexAccount {
     pub fn new() -> Self {
-        Self { client: Client::builder().user_agent("PresenceForPlex/1.0").timeout(TIMEOUT).build().expect("HTTP client"), username: None }
+        Self {
+            client: Client::builder()
+                .user_agent("PresenceForPlex/1.0")
+                .timeout(TIMEOUT)
+                .build()
+                .expect("HTTP client"),
+            username: None,
+        }
     }
 
-    pub fn username(&self) -> Option<&str> { self.username.as_deref() }
+    pub fn username(&self) -> Option<&str> {
+        self.username.as_deref()
+    }
 
     pub async fn fetch_username(&mut self, token: &str) -> Option<String> {
-        let json: serde_json::Value = self.client.get(format!("{}/user", PLEX_API))
+        let json: serde_json::Value = self
+            .client
+            .get(format!("{}/user", PLEX_API))
             .header("Accept", "application/json")
             .header("X-Plex-Token", token)
             .header("X-Plex-Client-Identifier", APP_NAME)
-            .send().await.ok()?.json().await.ok()?;
+            .send()
+            .await
+            .ok()?
+            .json()
+            .await
+            .ok()?;
         let username = json["username"].as_str()?.to_string();
         info!("Logged in as: {}", username);
         self.username = Some(username.clone());
@@ -42,37 +60,73 @@ impl PlexAccount {
     }
 
     pub async fn request_pin(&self) -> Option<(u64, String)> {
-        let json: serde_json::Value = self.client.post(format!("{}/pins", PLEX_API))
+        let json: serde_json::Value = self
+            .client
+            .post(format!("{}/pins", PLEX_API))
             .header("Accept", "application/json")
             .header("X-Plex-Product", "Presence for Plex")
             .header("X-Plex-Client-Identifier", APP_NAME)
             .query(&[("strong", "true")])
-            .send().await.ok()?.json().await.ok()?;
+            .send()
+            .await
+            .ok()?
+            .json()
+            .await
+            .ok()?;
         Some((json["id"].as_u64()?, json["code"].as_str()?.to_string()))
     }
 
     pub async fn check_pin(&self, pin_id: u64) -> Option<String> {
-        let json: serde_json::Value = self.client.get(format!("{}/pins/{}", PLEX_API, pin_id))
+        let json: serde_json::Value = self
+            .client
+            .get(format!("{}/pins/{}", PLEX_API, pin_id))
             .header("Accept", "application/json")
             .header("X-Plex-Client-Identifier", APP_NAME)
-            .send().await.ok()?.json().await.ok()?;
-        json["authToken"].as_str().filter(|s| !s.is_empty()).map(String::from)
+            .send()
+            .await
+            .ok()?
+            .json()
+            .await
+            .ok()?;
+        json["authToken"]
+            .as_str()
+            .filter(|s| !s.is_empty())
+            .map(String::from)
     }
 
     pub async fn get_servers(&self, token: &str) -> Option<Vec<ServerInfo>> {
-        let resources: Vec<PlexResource> = self.client.get(format!("{}/resources", PLEX_API))
+        let resources: Vec<PlexResource> = self
+            .client
+            .get(format!("{}/resources", PLEX_API))
             .header("Accept", "application/json")
             .header("X-Plex-Token", token)
             .header("X-Plex-Client-Identifier", APP_NAME)
             .query(&[("includeHttps", "1"), ("includeRelay", "1")])
-            .send().await.ok()?.json().await.ok()?;
+            .send()
+            .await
+            .ok()?
+            .json()
+            .await
+            .ok()?;
 
-        Some(resources.into_iter()
-            .filter(|r| r.provides.contains("server") && !r.connections.is_empty())
-            .map(|r| {
-                info!("Server: {} ({} connections)", r.name, r.connections.len());
-                ServerInfo { name: r.name, access_token: r.access_token, connections: r.connections.into_iter().map(|c| ServerConnection { uri: c.uri }).collect() }
-            }).collect())
+        Some(
+            resources
+                .into_iter()
+                .filter(|r| r.provides.contains("server") && !r.connections.is_empty())
+                .map(|r| {
+                    info!("Server: {} ({} connections)", r.name, r.connections.len());
+                    ServerInfo {
+                        name: r.name,
+                        access_token: r.access_token,
+                        connections: r
+                            .connections
+                            .into_iter()
+                            .map(|c| ServerConnection { uri: c.uri })
+                            .collect(),
+                    }
+                })
+                .collect(),
+        )
     }
 }
 
@@ -87,4 +141,6 @@ struct PlexResource {
 }
 
 #[derive(Deserialize)]
-struct PlexConnection { uri: String }
+struct PlexConnection {
+    uri: String,
+}

--- a/src/plex_server.rs
+++ b/src/plex_server.rs
@@ -7,82 +7,13 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{RwLock, mpsc};
 
+use crate::media::{MediaInfo, MediaType, MediaUpdate, PlaybackState};
 use crate::metadata::MetadataEnricher;
 use crate::plex_account::{APP_NAME, ServerConnection};
 
 const SSE_RECONNECT_DELAY: Duration = Duration::from_secs(5);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const SEEK_THRESHOLD_MS: u64 = 30_000;
-
-#[derive(Debug, Clone)]
-pub enum MediaUpdate {
-    Playing(Box<MediaInfo>),
-    Stopped,
-}
-
-#[derive(Debug, Clone)]
-pub struct MediaInfo {
-    pub title: String,
-    pub media_type: MediaType,
-    pub show_name: Option<String>,
-    pub season: Option<u32>,
-    pub episode: Option<u32>,
-    pub artist: Option<String>,
-    pub album: Option<String>,
-    pub year: Option<u32>,
-    pub genres: Vec<String>,
-    pub duration_ms: u64,
-    pub view_offset_ms: u64,
-    pub state: PlaybackState,
-    pub imdb_id: Option<String>,
-    pub tmdb_id: Option<String>,
-    pub mal_id: Option<String>,
-    pub art_url: Option<String>,
-    pub rating_key: Option<String>,
-    grandparent_key: Option<String>,
-    key: Option<String>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum MediaType {
-    Movie,
-    Episode,
-    Track,
-}
-
-#[cfg(test)]
-impl MediaInfo {
-    pub fn test_stub(media_type: MediaType) -> Self {
-        Self {
-            title: "Title".into(),
-            media_type,
-            show_name: None,
-            season: None,
-            episode: None,
-            artist: None,
-            album: None,
-            year: None,
-            genres: Vec::new(),
-            duration_ms: 0,
-            view_offset_ms: 0,
-            state: PlaybackState::Playing,
-            imdb_id: None,
-            tmdb_id: None,
-            mal_id: None,
-            art_url: None,
-            rating_key: None,
-            grandparent_key: None,
-            key: None,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum PlaybackState {
-    Playing,
-    Paused,
-    Buffering,
-}
 
 pub struct PlexServer {
     name: String,
@@ -167,7 +98,7 @@ impl PlexServer {
         info!("Monitoring server: {}", self.name);
         loop {
             for conn in &self.connections {
-                let _ = self.try_connection(&conn.uri, &tx, &enricher).await;
+                self.try_connection(&conn.uri, &tx, &enricher).await;
             }
             tokio::time::sleep(SSE_RECONNECT_DELAY).await;
         }
@@ -178,17 +109,21 @@ impl PlexServer {
         uri: &str,
         tx: &mpsc::UnboundedSender<MediaUpdate>,
         enricher: &Arc<MetadataEnricher>,
-    ) -> Result<(), ()> {
+    ) {
         let url = format!("{}/:/eventsource/notifications?filters=playing", uri);
-        let client = es::ClientBuilder::for_url(&url)
-            .map_err(|_| ())?
-            .header("Accept", "text/event-stream")
-            .map_err(|_| ())?
-            .header("X-Plex-Token", &self.access_token)
-            .map_err(|_| ())?
-            .header("X-Plex-Client-Identifier", APP_NAME)
-            .map_err(|_| ())?
-            .build();
+        let Ok(builder) = es::ClientBuilder::for_url(&url) else {
+            return;
+        };
+        let Ok(builder) = builder.header("Accept", "text/event-stream") else {
+            return;
+        };
+        let Ok(builder) = builder.header("X-Plex-Token", &self.access_token) else {
+            return;
+        };
+        let Ok(builder) = builder.header("X-Plex-Client-Identifier", APP_NAME) else {
+            return;
+        };
+        let client = builder.build();
 
         let mut stream = Box::pin(client.stream());
         let tracker = RwLock::new(PlaybackTracker::default());
@@ -211,7 +146,6 @@ impl PlexServer {
         if opened && tracker.write().await.clear_if_server(uri) {
             let _ = tx.send(MediaUpdate::Stopped);
         }
-        Err(())
     }
 
     async fn handle_message(

--- a/src/plex_server.rs
+++ b/src/plex_server.rs
@@ -5,10 +5,10 @@ use reqwest::Client;
 use serde::Deserialize;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{RwLock, mpsc};
 
 use crate::metadata::MetadataEnricher;
-use crate::plex_account::{ServerConnection, APP_NAME};
+use crate::plex_account::{APP_NAME, ServerConnection};
 
 const SSE_RECONNECT_DELAY: Duration = Duration::from_secs(5);
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
@@ -44,7 +44,11 @@ pub struct MediaInfo {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum MediaType { Movie, Episode, Track }
+pub enum MediaType {
+    Movie,
+    Episode,
+    Track,
+}
 
 #[cfg(test)]
 impl MediaInfo {
@@ -74,7 +78,11 @@ impl MediaInfo {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum PlaybackState { Playing, Paused, Buffering }
+pub enum PlaybackState {
+    Playing,
+    Paused,
+    Buffering,
+}
 
 pub struct PlexServer {
     name: String,
@@ -93,12 +101,18 @@ struct PlaybackTracker {
 
 impl PlaybackTracker {
     fn is_duplicate(&self, rating_key: &str, state: PlaybackState, offset: u64) -> bool {
-        let Some(ref info) = self.info else { return false };
+        let Some(ref info) = self.info else {
+            return false;
+        };
         if info.rating_key.as_deref() != Some(rating_key) || info.state != state {
             return false;
         }
-        let Some(last) = self.last_update else { return false };
-        let expected = info.view_offset_ms.saturating_add(last.elapsed().as_millis() as u64);
+        let Some(last) = self.last_update else {
+            return false;
+        };
+        let expected = info
+            .view_offset_ms
+            .saturating_add(last.elapsed().as_millis() as u64);
         expected.abs_diff(offset) <= SEEK_THRESHOLD_MS
     }
 
@@ -127,17 +141,29 @@ impl PlaybackTracker {
 }
 
 impl PlexServer {
-    pub fn new(name: String, connections: Vec<ServerConnection>, access_token: String, username: Option<String>) -> Self {
+    pub fn new(
+        name: String,
+        connections: Vec<ServerConnection>,
+        access_token: String,
+        username: Option<String>,
+    ) -> Self {
         Self {
             name,
             connections,
             access_token,
             username,
-            client: Client::builder().user_agent("PresenceForPlex/1.0").build().expect("HTTP client"),
+            client: Client::builder()
+                .user_agent("PresenceForPlex/1.0")
+                .build()
+                .expect("HTTP client"),
         }
     }
 
-    pub async fn start_monitoring(self, tx: mpsc::UnboundedSender<MediaUpdate>, enricher: Arc<MetadataEnricher>) {
+    pub async fn start_monitoring(
+        self,
+        tx: mpsc::UnboundedSender<MediaUpdate>,
+        enricher: Arc<MetadataEnricher>,
+    ) {
         info!("Monitoring server: {}", self.name);
         loop {
             for conn in &self.connections {
@@ -147,12 +173,21 @@ impl PlexServer {
         }
     }
 
-    async fn try_connection(&self, uri: &str, tx: &mpsc::UnboundedSender<MediaUpdate>, enricher: &Arc<MetadataEnricher>) -> Result<(), ()> {
+    async fn try_connection(
+        &self,
+        uri: &str,
+        tx: &mpsc::UnboundedSender<MediaUpdate>,
+        enricher: &Arc<MetadataEnricher>,
+    ) -> Result<(), ()> {
         let url = format!("{}/:/eventsource/notifications?filters=playing", uri);
-        let client = es::ClientBuilder::for_url(&url).map_err(|_| ())?
-            .header("Accept", "text/event-stream").map_err(|_| ())?
-            .header("X-Plex-Token", &self.access_token).map_err(|_| ())?
-            .header("X-Plex-Client-Identifier", APP_NAME).map_err(|_| ())?
+        let client = es::ClientBuilder::for_url(&url)
+            .map_err(|_| ())?
+            .header("Accept", "text/event-stream")
+            .map_err(|_| ())?
+            .header("X-Plex-Token", &self.access_token)
+            .map_err(|_| ())?
+            .header("X-Plex-Client-Identifier", APP_NAME)
+            .map_err(|_| ())?
             .build();
 
         let mut stream = Box::pin(client.stream());
@@ -161,8 +196,14 @@ impl PlexServer {
 
         while let Ok(Some(event)) = stream.try_next().await {
             match event {
-                SSE::Connected(_) => { opened = true; info!("SSE connected: {}", uri); }
-                SSE::Event(ev) => self.handle_message(&ev.data, uri, tx, enricher, &tracker).await,
+                SSE::Connected(_) => {
+                    opened = true;
+                    info!("SSE connected: {}", uri);
+                }
+                SSE::Event(ev) => {
+                    self.handle_message(&ev.data, uri, tx, enricher, &tracker)
+                        .await
+                }
                 SSE::Comment(_) => {}
             }
         }
@@ -173,9 +214,20 @@ impl PlexServer {
         Err(())
     }
 
-    async fn handle_message(&self, data: &str, uri: &str, tx: &mpsc::UnboundedSender<MediaUpdate>, enricher: &Arc<MetadataEnricher>, tracker: &RwLock<PlaybackTracker>) {
-        let Ok(notif) = serde_json::from_str::<SseNotification>(data) else { return };
-        let Some(playing) = notif.play_session_state else { return };
+    async fn handle_message(
+        &self,
+        data: &str,
+        uri: &str,
+        tx: &mpsc::UnboundedSender<MediaUpdate>,
+        enricher: &Arc<MetadataEnricher>,
+        tracker: &RwLock<PlaybackTracker>,
+    ) {
+        let Ok(notif) = serde_json::from_str::<SseNotification>(data) else {
+            return;
+        };
+        let Some(playing) = notif.play_session_state else {
+            return;
+        };
 
         if playing.state == "stopped" {
             let mut t = tracker.write().await;
@@ -197,7 +249,9 @@ impl PlexServer {
         {
             let mut t = tracker.write().await;
             if t.info.as_ref().and_then(|i| i.rating_key.as_deref()) == Some(&playing.rating_key) {
-                if t.is_duplicate(&playing.rating_key, state, offset) { return; }
+                if t.is_duplicate(&playing.rating_key, state, offset) {
+                    return;
+                }
                 t.update(state, offset);
                 if let Some(ref info) = t.info {
                     let _ = tx.send(MediaUpdate::Playing(Box::new(info.clone())));
@@ -211,7 +265,12 @@ impl PlexServer {
             return;
         }
 
-        let Some(mut info) = self.fetch_metadata(uri, &playing.rating_key, state, offset).await else { return };
+        let Some(mut info) = self
+            .fetch_metadata(uri, &playing.rating_key, state, offset)
+            .await
+        else {
+            return;
+        };
         info!("Now playing: {} ({:?})", info.title, info.state);
         enricher.enrich(&mut info).await;
 
@@ -220,22 +279,31 @@ impl PlexServer {
     }
 
     async fn is_own_session(&self, uri: &str, rating_key: &str) -> bool {
-        let Some(username) = &self.username else { return true };
+        let Some(username) = &self.username else {
+            return true;
+        };
 
-        let Ok(resp) = self.client
+        let Ok(resp) = self
+            .client
             .get(format!("{}/status/sessions", uri))
             .header("Accept", "application/json")
             .header("X-Plex-Token", &self.access_token)
             .header("X-Plex-Client-Identifier", APP_NAME)
             .timeout(REQUEST_TIMEOUT)
-            .send().await else { return false };
+            .send()
+            .await
+        else {
+            return false;
+        };
 
         // 403 means shared user (not owner) - they only receive their own session notifications
         if resp.status() == reqwest::StatusCode::FORBIDDEN {
             return true;
         }
 
-        let Ok(sessions) = resp.json::<SessionsResponse>().await else { return false };
+        let Ok(sessions) = resp.json::<SessionsResponse>().await else {
+            return false;
+        };
 
         sessions.media_container.metadata.iter().any(|m| {
             m.rating_key.as_deref() == Some(rating_key)
@@ -243,14 +311,23 @@ impl PlexServer {
         })
     }
 
-    async fn fetch_metadata(&self, uri: &str, rating_key: &str, state: PlaybackState, view_offset: u64) -> Option<MediaInfo> {
-        let resp = self.client
+    async fn fetch_metadata(
+        &self,
+        uri: &str,
+        rating_key: &str,
+        state: PlaybackState,
+        view_offset: u64,
+    ) -> Option<MediaInfo> {
+        let resp = self
+            .client
             .get(format!("{}/library/metadata/{}", uri, rating_key))
             .header("Accept", "application/json")
             .header("X-Plex-Token", &self.access_token)
             .header("X-Plex-Client-Identifier", APP_NAME)
             .timeout(REQUEST_TIMEOUT)
-            .send().await.ok()?;
+            .send()
+            .await
+            .ok()?;
 
         let meta_resp: MetadataResponse = resp.json().await.ok()?;
         let meta = meta_resp.media_container.metadata.into_iter().next()?;
@@ -268,20 +345,33 @@ impl PlexServer {
         };
         let Some(key) = key else { return };
 
-        let Some(resp) = self.client
+        let Some(resp) = self
+            .client
             .get(format!("{}{}", uri, key))
             .header("Accept", "application/json")
             .header("X-Plex-Token", &self.access_token)
             .header("X-Plex-Client-Identifier", APP_NAME)
             .timeout(REQUEST_TIMEOUT)
-            .send().await.ok() else { return };
+            .send()
+            .await
+            .ok()
+        else {
+            return;
+        };
 
-        let Ok(meta) = resp.json::<MetadataResponse>().await else { return };
-        let Some(item) = meta.media_container.metadata.into_iter().next() else { return };
+        let Ok(meta) = resp.json::<MetadataResponse>().await else {
+            return;
+        };
+        let Some(item) = meta.media_container.metadata.into_iter().next() else {
+            return;
+        };
 
         for guid in &item.guids {
-            if let Some(id) = guid.id.strip_prefix("imdb://") { info.imdb_id = Some(id.to_string()); }
-            else if let Some(id) = guid.id.strip_prefix("tmdb://") { info.tmdb_id = Some(id.to_string()); }
+            if let Some(id) = guid.id.strip_prefix("imdb://") {
+                info.imdb_id = Some(id.to_string());
+            } else if let Some(id) = guid.id.strip_prefix("tmdb://") {
+                info.tmdb_id = Some(id.to_string());
+            }
         }
 
         if info.media_type == MediaType::Episode {
@@ -289,7 +379,12 @@ impl PlexServer {
         }
     }
 
-    fn parse_metadata(meta: ItemMetadata, rating_key: &str, state: PlaybackState, view_offset: u64) -> Option<MediaInfo> {
+    fn parse_metadata(
+        meta: ItemMetadata,
+        rating_key: &str,
+        state: PlaybackState,
+        view_offset: u64,
+    ) -> Option<MediaInfo> {
         let media_type = match meta.media_type.as_str() {
             "movie" => MediaType::Movie,
             "episode" => MediaType::Episode,
@@ -298,8 +393,10 @@ impl PlexServer {
         };
 
         let (imdb_id, tmdb_id) = meta.guids.iter().fold((None, None), |(imdb, tmdb), g| {
-            (imdb.or_else(|| g.id.strip_prefix("imdb://").map(String::from)),
-             tmdb.or_else(|| g.id.strip_prefix("tmdb://").map(String::from)))
+            (
+                imdb.or_else(|| g.id.strip_prefix("imdb://").map(String::from)),
+                tmdb.or_else(|| g.id.strip_prefix("tmdb://").map(String::from)),
+            )
         });
 
         Some(MediaInfo {
@@ -343,11 +440,16 @@ struct PlaySessionState {
 
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
-struct SessionsResponse { media_container: MediaContainer }
+struct SessionsResponse {
+    media_container: MediaContainer,
+}
 
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
-struct MediaContainer { #[serde(default)] metadata: Vec<SessionMetadata> }
+struct MediaContainer {
+    #[serde(default)]
+    metadata: Vec<SessionMetadata>,
+}
 
 #[derive(Deserialize)]
 struct SessionMetadata {
@@ -358,21 +460,32 @@ struct SessionMetadata {
 }
 
 #[derive(Deserialize)]
-struct UserInfo { title: String }
+struct UserInfo {
+    title: String,
+}
 
 #[derive(Deserialize)]
-struct GuidTag { id: String }
+struct GuidTag {
+    id: String,
+}
 
 #[derive(Deserialize)]
-struct GenreTag { tag: String }
+struct GenreTag {
+    tag: String,
+}
 
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
-struct MetadataResponse { media_container: MetadataContainer }
+struct MetadataResponse {
+    media_container: MetadataContainer,
+}
 
 #[derive(Deserialize)]
 #[serde(rename_all = "PascalCase")]
-struct MetadataContainer { #[serde(default)] metadata: Vec<ItemMetadata> }
+struct MetadataContainer {
+    #[serde(default)]
+    metadata: Vec<ItemMetadata>,
+}
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -458,7 +571,8 @@ mod tests {
 
     #[test]
     fn parse_metadata_maps_episode_fields() {
-        let meta: ItemMetadata = serde_json::from_str(r#"{
+        let meta: ItemMetadata = serde_json::from_str(
+            r#"{
             "title": "The One Where It Works",
             "type": "episode",
             "duration": 1320000,
@@ -470,7 +584,9 @@ mod tests {
             "Guid": [{"id": "imdb://tt0583459"}, {"id": "tmdb://123"}],
             "Genre": [{"tag": "Comedy"}],
             "grandparentKey": "/library/metadata/100"
-        }"#).unwrap();
+        }"#,
+        )
+        .unwrap();
 
         let info = PlexServer::parse_metadata(meta, "42", PlaybackState::Playing, 5000).unwrap();
         assert_eq!(info.media_type, MediaType::Episode);
@@ -484,17 +600,23 @@ mod tests {
         assert_eq!(info.duration_ms, 1320000);
         assert_eq!(info.view_offset_ms, 5000);
         assert_eq!(info.rating_key.as_deref(), Some("42"));
-        assert_eq!(info.grandparent_key.as_deref(), Some("/library/metadata/100"));
+        assert_eq!(
+            info.grandparent_key.as_deref(),
+            Some("/library/metadata/100")
+        );
     }
 
     #[test]
     fn parse_metadata_maps_track_fields() {
-        let meta: ItemMetadata = serde_json::from_str(r#"{
+        let meta: ItemMetadata = serde_json::from_str(
+            r#"{
             "title": "Song",
             "type": "track",
             "grandparentTitle": "Artist",
             "parentTitle": "Album"
-        }"#).unwrap();
+        }"#,
+        )
+        .unwrap();
 
         let info = PlexServer::parse_metadata(meta, "7", PlaybackState::Paused, 0).unwrap();
         assert_eq!(info.media_type, MediaType::Track);
@@ -505,19 +627,23 @@ mod tests {
 
     #[test]
     fn parse_metadata_rejects_unknown_types() {
-        let meta: ItemMetadata = serde_json::from_str(r#"{"title": "Photo", "type": "photo"}"#).unwrap();
+        let meta: ItemMetadata =
+            serde_json::from_str(r#"{"title": "Photo", "type": "photo"}"#).unwrap();
         assert!(PlexServer::parse_metadata(meta, "1", PlaybackState::Playing, 0).is_none());
     }
 
     #[test]
     fn sse_notification_parses_plex_payload() {
-        let notif: SseNotification = serde_json::from_str(r#"{
+        let notif: SseNotification = serde_json::from_str(
+            r#"{
             "PlaySessionStateNotification": {
                 "state": "playing",
                 "ratingKey": "123",
                 "viewOffset": 60000
             }
-        }"#).unwrap();
+        }"#,
+        )
+        .unwrap();
         let playing = notif.play_session_state.unwrap();
         assert_eq!(playing.state, "playing");
         assert_eq!(playing.rating_key, "123");

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -7,25 +7,53 @@ const DEFAULT_IMAGE: &str = "plex_logo";
 pub fn build_presence(info: &MediaInfo, config: &Config) -> Presence {
     let (details_tpl, state_tpl, image_tpl) = match info.media_type {
         MediaType::Episode => (&config.tv_details, &config.tv_state, &config.tv_image_text),
-        MediaType::Movie => (&config.movie_details, &config.movie_state, &config.movie_image_text),
-        MediaType::Track => (&config.music_details, &config.music_state, &config.music_image_text),
+        MediaType::Movie => (
+            &config.movie_details,
+            &config.movie_state,
+            &config.movie_image_text,
+        ),
+        MediaType::Track => (
+            &config.music_details,
+            &config.music_state,
+            &config.music_image_text,
+        ),
     };
 
     let mut buttons = Vec::new();
     if config.show_buttons {
-        if let Some(ref id) = info.mal_id { buttons.push(Button { label: "View on MyAnimeList".into(), url: format!("https://myanimelist.net/anime/{}", id) }); }
-        if let Some(ref id) = info.imdb_id && buttons.len() < 2 { buttons.push(Button { label: "View on IMDb".into(), url: format!("https://www.imdb.com/title/{}", id) }); }
+        if let Some(ref id) = info.mal_id {
+            buttons.push(Button {
+                label: "View on MyAnimeList".into(),
+                url: format!("https://myanimelist.net/anime/{}", id),
+            });
+        }
+        if let Some(ref id) = info.imdb_id
+            && buttons.len() < 2
+        {
+            buttons.push(Button {
+                label: "View on IMDb".into(),
+                url: format!("https://www.imdb.com/title/{}", id),
+            });
+        }
     }
 
     Presence {
         details: format_template(details_tpl, info),
         state: format_template(state_tpl, info),
-        large_image: Some(if config.show_artwork { info.art_url.clone().unwrap_or_else(|| DEFAULT_IMAGE.into()) } else { DEFAULT_IMAGE.into() }),
+        large_image: Some(if config.show_artwork {
+            info.art_url.clone().unwrap_or_else(|| DEFAULT_IMAGE.into())
+        } else {
+            DEFAULT_IMAGE.into()
+        }),
         large_image_text: format_template(image_tpl, info),
         progress_ms: info.view_offset_ms,
         duration_ms: info.duration_ms,
         show_timestamps: config.show_progress,
-        activity_type: if info.media_type == MediaType::Track { ActivityType::Listening } else { ActivityType::Watching },
+        activity_type: if info.media_type == MediaType::Track {
+            ActivityType::Listening
+        } else {
+            ActivityType::Watching
+        },
         playback_state: info.state,
         buttons,
     }
@@ -37,11 +65,18 @@ fn format_template(template: &str, info: &MediaInfo) -> String {
 
     while let Some(c) = chars.next() {
         if c == '{' {
-            if chars.peek() == Some(&'{') { chars.next(); result.push('{'); continue; }
+            if chars.peek() == Some(&'{') {
+                chars.next();
+                result.push('{');
+                continue;
+            }
             let mut placeholder = String::new();
             let mut closed = false;
             for ch in chars.by_ref() {
-                if ch == '}' { closed = true; break; }
+                if ch == '}' {
+                    closed = true;
+                    break;
+                }
                 placeholder.push(ch);
             }
             if !closed {
@@ -53,17 +88,41 @@ fn format_template(template: &str, info: &MediaInfo) -> String {
             match placeholder.as_str() {
                 "show" => result.push_str(info.show_name.as_deref().unwrap_or("")),
                 "title" => result.push_str(&info.title),
-                "se" => if let (Some(s), Some(e)) = (info.season, info.episode) { result.push_str(&format!("S{s:02}E{e:02}")); },
-                "season" => if let Some(s) = info.season { result.push_str(&s.to_string()); },
-                "episode" => if let Some(e) = info.episode { result.push_str(&e.to_string()); },
-                "year" => if let Some(y) = info.year { result.push_str(&y.to_string()); },
+                "se" => {
+                    if let (Some(s), Some(e)) = (info.season, info.episode) {
+                        result.push_str(&format!("S{s:02}E{e:02}"));
+                    }
+                }
+                "season" => {
+                    if let Some(s) = info.season {
+                        result.push_str(&s.to_string());
+                    }
+                }
+                "episode" => {
+                    if let Some(e) = info.episode {
+                        result.push_str(&e.to_string());
+                    }
+                }
+                "year" => {
+                    if let Some(y) = info.year {
+                        result.push_str(&y.to_string());
+                    }
+                }
                 "genres" => result.push_str(&info.genres.join(", ")),
                 "artist" => result.push_str(info.artist.as_deref().unwrap_or("")),
                 "album" => result.push_str(info.album.as_deref().unwrap_or("")),
-                _ => { result.push('{'); result.push_str(&placeholder); result.push('}'); }
+                _ => {
+                    result.push('{');
+                    result.push_str(&placeholder);
+                    result.push('}');
+                }
             }
-        } else if c == '}' && chars.peek() == Some(&'}') { chars.next(); result.push('}'); }
-        else { result.push(c); }
+        } else if c == '}' && chars.peek() == Some(&'}') {
+            chars.next();
+            result.push('}');
+        } else {
+            result.push(c);
+        }
     }
     result
 }
@@ -88,7 +147,10 @@ mod tests {
         let info = episode_info();
         assert_eq!(format_template("{show}: {title}", &info), "The Show: Pilot");
         assert_eq!(format_template("S{season} · E{episode}", &info), "S1 · E2");
-        assert_eq!(format_template("{year} [{genres}]", &info), "2020 [Drama, Comedy]");
+        assert_eq!(
+            format_template("{year} [{genres}]", &info),
+            "2020 [Drama, Comedy]"
+        );
     }
 
     #[test]
@@ -100,7 +162,10 @@ mod tests {
     #[test]
     fn missing_values_render_empty() {
         let info = MediaInfo::test_stub(MediaType::Movie);
-        assert_eq!(format_template("{show}{season}{episode}{year}{se}", &info), "");
+        assert_eq!(
+            format_template("{show}{season}{episode}{year}{se}", &info),
+            ""
+        );
         assert_eq!(format_template("{artist} - {album}", &info), " - ");
     }
 
@@ -113,7 +178,10 @@ mod tests {
     #[test]
     fn escaped_braces_are_literal() {
         let info = episode_info();
-        assert_eq!(format_template("{{title}} = {title}", &info), "{title} = Pilot");
+        assert_eq!(
+            format_template("{{title}} = {title}", &info),
+            "{title} = Pilot"
+        );
     }
 
     #[test]
@@ -137,7 +205,10 @@ mod tests {
     fn build_presence_respects_show_buttons_toggle() {
         let mut info = episode_info();
         info.imdb_id = Some("tt1".into());
-        let config = Config { show_buttons: false, ..Config::default() };
+        let config = Config {
+            show_buttons: false,
+            ..Config::default()
+        };
         assert!(build_presence(&info, &config).buttons.is_empty());
     }
 
@@ -156,7 +227,10 @@ mod tests {
         info.art_url = Some("https://img.example/x.jpg".into());
         let p = build_presence(&info, &Config::default());
         assert_eq!(p.large_image.as_deref(), Some("https://img.example/x.jpg"));
-        let config = Config { show_artwork: false, ..Config::default() };
+        let config = Config {
+            show_artwork: false,
+            ..Config::default()
+        };
         let p = build_presence(&info, &config);
         assert_eq!(p.large_image.as_deref(), Some(DEFAULT_IMAGE));
     }

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use crate::discord::{ActivityType, Button, Presence};
-use crate::plex_server::{MediaInfo, MediaType};
+use crate::media::{MediaInfo, MediaType};
 
 const DEFAULT_IMAGE: &str = "plex_logo";
 

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -2,18 +2,29 @@ use crossbeam_channel::RecvTimeoutError;
 use image::GenericImageView;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
-use tray_icon::{menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem}, Icon, TrayIconBuilder};
+use tray_icon::{
+    Icon, TrayIconBuilder,
+    menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem},
+};
 
 use crate::plex_server::PlaybackState;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TrayStatus { Idle, Playing, Paused, Buffering, NotAuthenticated }
+pub enum TrayStatus {
+    Idle,
+    Playing,
+    Paused,
+    Buffering,
+    NotAuthenticated,
+}
 
 impl TrayStatus {
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::Idle => "Status: Idle", Self::Playing => "Status: Playing",
-            Self::Paused => "Status: Paused", Self::Buffering => "Status: Buffering",
+            Self::Idle => "Status: Idle",
+            Self::Playing => "Status: Playing",
+            Self::Paused => "Status: Paused",
+            Self::Buffering => "Status: Buffering",
             Self::NotAuthenticated => "Status: Not Authenticated",
         }
     }
@@ -21,12 +32,19 @@ impl TrayStatus {
 
 impl From<PlaybackState> for TrayStatus {
     fn from(s: PlaybackState) -> Self {
-        match s { PlaybackState::Playing => Self::Playing, PlaybackState::Paused => Self::Paused, PlaybackState::Buffering => Self::Buffering }
+        match s {
+            PlaybackState::Playing => Self::Playing,
+            PlaybackState::Paused => Self::Paused,
+            PlaybackState::Buffering => Self::Buffering,
+        }
     }
 }
 
 #[derive(Debug)]
-pub enum TrayCommand { Quit, Authenticate }
+pub enum TrayCommand {
+    Quit,
+    Authenticate,
+}
 
 #[cfg(target_os = "linux")]
 enum MenuTextUpdate {
@@ -50,7 +68,9 @@ impl TrayHandle {
         #[cfg(not(target_os = "linux"))]
         self.status_item.set_text(text);
         #[cfg(target_os = "linux")]
-        let _ = self.update_tx.send(MenuTextUpdate::Status(text.to_string()));
+        let _ = self
+            .update_tx
+            .send(MenuTextUpdate::Status(text.to_string()));
     }
 
     pub fn set_auth_text(&self, text: &str) {
@@ -61,10 +81,30 @@ impl TrayHandle {
     }
 }
 
-fn build_tray(tx: UnboundedSender<TrayCommand>, authenticated: bool) -> Option<(MenuItem, MenuItem, tray_icon::TrayIcon)> {
+fn build_tray(
+    tx: UnboundedSender<TrayCommand>,
+    authenticated: bool,
+) -> Option<(MenuItem, MenuItem, tray_icon::TrayIcon)> {
     let menu = Menu::new();
-    let status_item = MenuItem::new(if authenticated { TrayStatus::Idle } else { TrayStatus::NotAuthenticated }.as_str(), false, None);
-    let auth_item = MenuItem::new(if authenticated { "Reauthenticate" } else { "Authenticate with Plex" }, true, None);
+    let status_item = MenuItem::new(
+        if authenticated {
+            TrayStatus::Idle
+        } else {
+            TrayStatus::NotAuthenticated
+        }
+        .as_str(),
+        false,
+        None,
+    );
+    let auth_item = MenuItem::new(
+        if authenticated {
+            "Reauthenticate"
+        } else {
+            "Authenticate with Plex"
+        },
+        true,
+        None,
+    );
     let quit_item = MenuItem::new("Quit", true, None);
 
     menu.append(&status_item).ok()?;
@@ -76,7 +116,12 @@ fn build_tray(tx: UnboundedSender<TrayCommand>, authenticated: bool) -> Option<(
     let (w, h) = img.dimensions();
     let icon = Icon::from_rgba(img.to_rgba8().into_raw(), w, h).ok()?;
 
-    let tray = TrayIconBuilder::new().with_menu(Box::new(menu)).with_tooltip("Presence for Plex").with_icon(icon).build().ok()?;
+    let tray = TrayIconBuilder::new()
+        .with_menu(Box::new(menu))
+        .with_tooltip("Presence for Plex")
+        .with_icon(icon)
+        .build()
+        .ok()?;
 
     let (auth_id, quit_id) = (auth_item.id().clone(), quit_item.id().clone());
 
@@ -84,8 +129,13 @@ fn build_tray(tx: UnboundedSender<TrayCommand>, authenticated: bool) -> Option<(
         let recv = MenuEvent::receiver();
         loop {
             match recv.recv_timeout(Duration::from_millis(100)) {
-                Ok(e) if e.id == quit_id => { let _ = tx.send(TrayCommand::Quit); break; }
-                Ok(e) if e.id == auth_id => { let _ = tx.send(TrayCommand::Authenticate); }
+                Ok(e) if e.id == quit_id => {
+                    let _ = tx.send(TrayCommand::Quit);
+                    break;
+                }
+                Ok(e) if e.id == auth_id => {
+                    let _ = tx.send(TrayCommand::Authenticate);
+                }
                 Ok(_) => {}
                 Err(RecvTimeoutError::Timeout) if tx.is_closed() => break,
                 Err(RecvTimeoutError::Disconnected) => break,
@@ -130,12 +180,18 @@ pub fn setup(tx: UnboundedSender<TrayCommand>, authenticated: bool) -> Option<Tr
 
         gtk::main();
     });
-    if !ready_rx.recv().ok()? { return None; }
+    if !ready_rx.recv().ok()? {
+        return None;
+    }
     Some(TrayHandle { update_tx })
 }
 
 #[cfg(not(target_os = "linux"))]
 pub fn setup(tx: UnboundedSender<TrayCommand>, authenticated: bool) -> Option<TrayHandle> {
     let (status_item, auth_item, tray) = build_tray(tx, authenticated)?;
-    Some(TrayHandle { _tray: tray, status_item, auth_item })
+    Some(TrayHandle {
+        _tray: tray,
+        status_item,
+        auth_item,
+    })
 }

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -7,7 +7,7 @@ use tray_icon::{
     menu::{Menu, MenuEvent, MenuItem, PredefinedMenuItem},
 };
 
-use crate::plex_server::PlaybackState;
+use crate::media::PlaybackState;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrayStatus {
@@ -165,7 +165,7 @@ pub fn setup(tx: UnboundedSender<TrayCommand>, authenticated: bool) -> Option<Tr
         let (status_item, auth_item, _tray) = result.unwrap();
         ready_tx.send(true).ok();
 
-        // Process text updates from main thread via glib idle callbacks
+        // Menu items may only be touched from the GTK thread
         let status = status_item.clone();
         let auth = auth_item.clone();
         gtk::glib::timeout_add_local(Duration::from_millis(50), move || {


### PR DESCRIPTION
Maintainability pass. No behavior changes intended.

Two commits, best reviewed separately:

1. **Format with rustfmt and enforce in CI** (mechanical only). CI now runs `cargo fmt --check`.
2. **Restructure for readability**:
   - New `media.rs` owns the shared data model (`MediaInfo`, `MediaType`, `PlaybackState`, `MediaUpdate`). Consumers no longer import types from the Plex networking module, so the dependency direction is clear: `plex_server` produces media state, `presence`/`discord`/`metadata` consume it.
   - `main()` now reads as a plain startup/shutdown sequence. The tray select loop moved into `run_tray`, which also absorbed the tray-unavailable fallback and works with a real `TrayHandle` instead of `if let Some(h)` on every line.
   - The duplicated tray/headless `handle_media` functions collapsed into one with a `#[cfg(feature = "tray")]` parameter.
   - The two copy-pasted caches in `metadata.rs` are now a single `Cache` type; `cache_key` became a free function.
   - Dropped the `fs2` dependency (std file locking covers it), removed ignored `Result` returns from `try_connection`/`try_tmdb`, and trimmed comments that restated the code.

No new abstractions: no traits, no extra layers, eight flat modules.

Verified: clippy `-D warnings` and all 29 tests pass on both feature sets; headless binary smoke-runs cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bq7rGEpJnff3TYSemYFhPW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bq7rGEpJnff3TYSemYFhPW)_